### PR TITLE
Android updates

### DIFF
--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(rmw_implementation_cmake REQUIRED)
 find_package(rcljava_common REQUIRED)
 find_package(JavaExtra MODULE)
 
+include(CrossCompilingExtra)
+
 if(ANDROID)
   find_host_package(Java COMPONENTS Development)
 else()

--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(rcl REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 find_package(rcljava_common REQUIRED)
-find_package(JavaExtra MODULE)
 
 include(CrossCompilingExtra)
 
@@ -20,6 +19,7 @@ else()
 endif()
 
 include(UseJava)
+include(JavaExtra)
 
 set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.6" "-target" "1.6")
 

--- a/rcljava_common/CMakeLists.txt
+++ b/rcljava_common/CMakeLists.txt
@@ -46,45 +46,65 @@ find_jar(SFL4J_JAR NAMES slf4j-api)
 if(${SFL4J_JAR})
   ament_export_jars(${SFL4J_JAR})
 else()
-  set(log4j_version "1.2.17")
   set(slf4j_version "1.7.21")
-
-  set(log4j_sha256 "1d31696445697720527091754369082a6651bd49781b6005deb94e56753406f9")
   set(slf4j_api_sha256 "1d5aeb6bd98b0fdd151269eae941c05f6468a791ea0f1e68d8e7fe518af3e7df")
-  set(slf4j_log4j_sha256 "9563e26fd7863cca0f5d468ef09f2927047f8b85a8c76d98766ed5863cb678b2")
-  set(slf4j_android_sha256 "3874b0975f9ad283328c0371ccde2de353754da33fda36e611702623ee1e5a95")
-  set(slf4j_jdk14_sha256 "2c369503c911bf9ac7c5f4813bc1f8f95866e2e029fae203a02712f5671f5e4a")
-
-  set(log4j_url "http://central.maven.org/maven2/log4j/log4j/${log4j_version}/log4j-${log4j_version}.jar")
   set(slf4j_api_url "http://central.maven.org/maven2/org/slf4j/slf4j-api/${slf4j_version}/slf4j-api-${slf4j_version}.jar")
-  set(slf4j_log4j_url "http://central.maven.org/maven2/org/slf4j/slf4j-log4j12/${slf4j_version}/slf4j-log4j12-${slf4j_version}.jar")
-  set(slf4j_android_url "http://central.maven.org/maven2/org/slf4j/slf4j-android/${slf4j_version}/slf4j-android-${slf4j_version}.jar")
-  set(slf4j_jdk14_url "http://central.maven.org/maven2/org/slf4j/slf4j-jdk14/${slf4j_version}/slf4j-jdk14-${slf4j_version}.jar")
-
-  set(log4j_jar_path "${CMAKE_CURRENT_BINARY_DIR}/jars/log4j-${log4j_version}.jar")
   set(slf4j_api_jar_path "${CMAKE_CURRENT_BINARY_DIR}/jars/slf4j-api-${slf4j_version}.jar")
-  set(slf4j_log4j_jar_path "${CMAKE_CURRENT_BINARY_DIR}/jars/slf4j-log4j12-${slf4j_version}.jar")
-  set(slf4j_android_jar_path "${CMAKE_CURRENT_BINARY_DIR}/jars/slf4j-android-${slf4j_version}.jar")
-  set(slf4j_jdk14_jar_path "${CMAKE_CURRENT_BINARY_DIR}/jars/slf4j-jdk14-${slf4j_version}.jar")
-
-  file(DOWNLOAD ${log4j_url} ${log4j_jar_path} EXPECTED_HASH SHA256=${log4j_sha256})
   file(DOWNLOAD ${slf4j_api_url} ${slf4j_api_jar_path} EXPECTED_HASH SHA256=${slf4j_api_sha256})
-  file(DOWNLOAD ${slf4j_log4j_url} ${slf4j_log4j_jar_path} EXPECTED_HASH SHA256=${slf4j_log4j_sha256})
-  file(DOWNLOAD ${slf4j_android_url} ${slf4j_android_jar_path} EXPECTED_HASH SHA256=${slf4j_android_sha256})
-  file(DOWNLOAD ${slf4j_jdk14_url} ${slf4j_jdk14_jar_path} EXPECTED_HASH SHA256=${slf4j_jdk14_sha256})
 
   install(FILES
-    ${log4j_jar_path} ${slf4j_api_jar_path}
-    ${slf4j_log4j_jar_path} ${slf4j_android_jar_path}
-    ${slf4j_jdk14_jar_path}
+    ${slf4j_api_jar_path}
     DESTINATION
     "share/${PROJECT_NAME}/java")
 
-  ament_export_jars("share/${PROJECT_NAME}/java/log4j-${log4j_version}.jar")
   ament_export_jars("share/${PROJECT_NAME}/java/slf4j-api-${slf4j_version}.jar")
-  ament_export_jars("share/${PROJECT_NAME}/java/slf4j-log4j12-${slf4j_version}.jar")
-  ament_export_jars("share/${PROJECT_NAME}/java/slf4j-android-${slf4j_version}.jar")
-  ament_export_jars("share/${PROJECT_NAME}/java/slf4j-jdk14-${slf4j_version}.jar")
+
+  if(ANDROID)
+    set(slf4j_android_sha256 "3874b0975f9ad283328c0371ccde2de353754da33fda36e611702623ee1e5a95")
+    set(slf4j_android_url "http://central.maven.org/maven2/org/slf4j/slf4j-android/${slf4j_version}/slf4j-android-${slf4j_version}.jar")
+    set(slf4j_android_jar_path "${CMAKE_CURRENT_BINARY_DIR}/jars/slf4j-android-${slf4j_version}.jar")
+    file(DOWNLOAD ${slf4j_android_url} ${slf4j_android_jar_path} EXPECTED_HASH SHA256=${slf4j_android_sha256})
+    list(APPEND logging_jars "${slf4j_android_jar_path}")
+
+    install(FILES
+      ${slf4j_android_jar_path}
+      DESTINATION
+      "share/${PROJECT_NAME}/java")
+
+    ament_export_jars("share/${PROJECT_NAME}/java/slf4j-android-${slf4j_version}.jar")
+  else()
+    set(log4j_version "1.2.17")
+
+    set(log4j_sha256 "1d31696445697720527091754369082a6651bd49781b6005deb94e56753406f9")
+    set(slf4j_log4j_sha256 "9563e26fd7863cca0f5d468ef09f2927047f8b85a8c76d98766ed5863cb678b2")
+    set(slf4j_jdk14_sha256 "2c369503c911bf9ac7c5f4813bc1f8f95866e2e029fae203a02712f5671f5e4a")
+
+    set(log4j_url "http://central.maven.org/maven2/log4j/log4j/${log4j_version}/log4j-${log4j_version}.jar")
+    set(slf4j_log4j_url "http://central.maven.org/maven2/org/slf4j/slf4j-log4j12/${slf4j_version}/slf4j-log4j12-${slf4j_version}.jar")
+    set(slf4j_jdk14_url "http://central.maven.org/maven2/org/slf4j/slf4j-jdk14/${slf4j_version}/slf4j-jdk14-${slf4j_version}.jar")
+
+    set(log4j_jar_path "${CMAKE_CURRENT_BINARY_DIR}/jars/log4j-${log4j_version}.jar")
+    set(slf4j_log4j_jar_path "${CMAKE_CURRENT_BINARY_DIR}/jars/slf4j-log4j12-${slf4j_version}.jar")
+    set(slf4j_jdk14_jar_path "${CMAKE_CURRENT_BINARY_DIR}/jars/slf4j-jdk14-${slf4j_version}.jar")
+
+    file(DOWNLOAD ${log4j_url} ${log4j_jar_path} EXPECTED_HASH SHA256=${log4j_sha256})
+    file(DOWNLOAD ${slf4j_log4j_url} ${slf4j_log4j_jar_path} EXPECTED_HASH SHA256=${slf4j_log4j_sha256})
+    file(DOWNLOAD ${slf4j_jdk14_url} ${slf4j_jdk14_jar_path} EXPECTED_HASH SHA256=${slf4j_jdk14_sha256})
+    list(APPEND logging_jars "${log4j_jar_path}")
+    list(APPEND logging_jars "${slf4j_log4j_jar_path}")
+    list(APPEND logging_jars "${slf4j_jdk14_jar_path}")
+
+    install(FILES
+      ${log4j_jar_path} ${slf4j_api_jar_path}
+      ${slf4j_log4j_jar_path} ${slf4j_android_jar_path}
+      ${slf4j_jdk14_jar_path}
+      DESTINATION
+      "share/${PROJECT_NAME}/java")
+
+    ament_export_jars("share/${PROJECT_NAME}/java/log4j-${log4j_version}.jar")
+    ament_export_jars("share/${PROJECT_NAME}/java/slf4j-log4j12-${slf4j_version}.jar")
+    ament_export_jars("share/${PROJECT_NAME}/java/slf4j-jdk14-${slf4j_version}.jar")
+  endif()
 endif()
 
 include_directories(include)

--- a/rcljava_common/CMakeLists.txt
+++ b/rcljava_common/CMakeLists.txt
@@ -7,6 +7,10 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_export_jars REQUIRED)
 find_package(ament_cmake_export_libraries REQUIRED)
 
+list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
+
+include(CrossCompilingExtra)
+
 if(ANDROID)
   find_host_package(Java COMPONENTS Development REQUIRED)
 else()

--- a/rcljava_common/cmake/Modules/CrossCompilingExtra.cmake
+++ b/rcljava_common/cmake/Modules/CrossCompilingExtra.cmake
@@ -1,0 +1,58 @@
+# Copyright 2016 Esteve Fernandez <esteve@apache.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Based on https://goo.gl/UsQN1c
+# Used a URL shortener to avoid complaints from link_cmake
+
+# macro to find packages on the host OS
+macro( find_host_package )
+  set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER )
+  set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY NEVER )
+  set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE NEVER )
+  if( CMAKE_HOST_WIN32 )
+    set( WIN32 1 )
+    set( UNIX )
+  elseif( CMAKE_HOST_APPLE )
+    set( APPLE 1 )
+    set( UNIX )
+  endif()
+  find_package( ${ARGN} )
+  set( WIN32 )
+  set( APPLE )
+  set( UNIX 1 )
+  set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY )
+  set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
+  set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )
+endmacro()
+
+# macro to find programs on the host OS
+macro( find_host_program )
+  set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER )
+  set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY NEVER )
+  set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE NEVER )
+  if( CMAKE_HOST_WIN32 )
+    set( WIN32 1 )
+    set( UNIX )
+  elseif( CMAKE_HOST_APPLE )
+    set( APPLE 1 )
+    set( UNIX )
+  endif()
+  find_program( ${ARGN} )
+  set( WIN32 )
+  set( APPLE )
+  set( UNIX 1 )
+  set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY )
+  set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
+  set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )
+endmacro()

--- a/rcljava_common/cmake/Modules/JavaExtra.cmake
+++ b/rcljava_common/cmake/Modules/JavaExtra.cmake
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(CrossCompilingExtra)
+
 if(ANDROID)
   find_host_package(Java COMPONENTS Development)
 else()

--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -51,7 +51,3 @@ repositories:
     type: git
     url: https://github.com/esteve/rosidl_typesupport.git
     version: android
-  android-cmake/android-cmake:
-    type: git
-    url: https://github.com/chenxiaolong/android-cmake.git
-    version: mbp

--- a/rosidl_generator_java/CMakeLists.txt
+++ b/rosidl_generator_java/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(rosidl_generator_c REQUIRED)
 
 find_package(rcljava_common REQUIRED)
 
+include(CrossCompilingExtra)
+
 ament_export_dependencies(rosidl_cmake)
 
 ament_python_install_package(${PROJECT_NAME})

--- a/rosidl_generator_java/cmake/rosidl_generator_java_generate_interfaces.cmake
+++ b/rosidl_generator_java/cmake/rosidl_generator_java_generate_interfaces.cmake
@@ -18,6 +18,8 @@ find_package(rmw_implementation_cmake REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rcljava_common REQUIRED)
 
+include(CrossCompilingExtra)
+
 if(ANDROID)
   find_host_package(Java COMPONENTS Development REQUIRED)
 else()


### PR DESCRIPTION
Updated CMake scripts for Android's latest NDK (13b). Fixed duplicate SFL4J DEX entries by downloading only the Android logging backend, and not Log4J and JUL.

CI:

Android https://travis-ci.org/esteve/ros2_android/builds/177724298
Java https://travis-ci.org/esteve/ros2_java/builds/177724248