### PR TITLE
Cache JNI reflection

### DIFF
--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -192,6 +192,8 @@ if(BUILD_TESTING)
       LIBRARY_PATHS
       "${_deps_library_paths}"
     )
+
+    add_dependencies("${PROJECT_NAME}_tests_${testsuite}" "${PROJECT_NAME}_messages_jar")
   endforeach()
 
 endif()

--- a/rcljava_common/cmake/Modules/JavaExtra.cmake
+++ b/rcljava_common/cmake/Modules/JavaExtra.cmake
@@ -125,4 +125,8 @@ function(add_junit_tests TARGET_NAME)
     ${JVMARGS} -classpath ${${TARGET_NAME}_jar_dependencies} -Djava.library.path=${_library_paths}
     org.junit.runner.JUnitCore ${_add_junit_tests_TESTS}
   )
+
+  add_custom_target(${TARGET_NAME} DEPENDS ${_jar_test_file})
+
+  add_dependencies(${TARGET_NAME} "${TARGET_NAME}_jar")
 endfunction()

--- a/rosidl_generator_java/CMakeLists.txt
+++ b/rosidl_generator_java/CMakeLists.txt
@@ -92,6 +92,8 @@ if(BUILD_TESTING)
       "${rosidl_generator_java_JARS}"
       "${_${PROJECT_NAME}_messages_jar_file}"
     )
+
+    add_dependencies("${PROJECT_NAME}_tests_${testsuite}" "${PROJECT_NAME}_messages_jar")
   endforeach()
 
 endif()

--- a/rosidl_generator_java/resource/msg_support.entry_point.cpp.template
+++ b/rosidl_generator_java/resource/msg_support.entry_point.cpp.template
@@ -1,7 +1,11 @@
+#include <cstdint>
 #include <jni.h>
+
+// Ensure that a jlong is big enough to store raw pointers
+static_assert(sizeof(jlong) >= sizeof(std::intptr_t), "jlong must be able to store pointers");
+
 #include <stdio.h>
 #include <cassert>
-#include <cstdint>
 #include <string>
 
 #include <@(spec.base_type.pkg_name)/@(subfolder)/@(module_name).h>
@@ -16,6 +20,90 @@
 #include <rcljava_common/exceptions.h>
 #include <rcljava_common/signatures.h>
 
+@#JNI performance tips taken from http://planet.jboss.org/post/jni_performance_the_saga_continues
+
+@{
+
+from collections import defaultdict
+
+def get_normalized_type(type_, subfolder='msg'):
+    return get_java_type(type_, use_primitives=False, subfolder=subfolder).replace('.', '__')
+
+def get_jni_type(type_, subfolder='msg'):
+    return get_java_type(type_, use_primitives=False, subfolder=subfolder).replace('.', '/')
+
+constructor_signatures = defaultdict(lambda: "()V")
+constructor_signatures['java/lang/Boolean'] = "(Z)V"
+constructor_signatures['java/lang/Byte'] = "(B)V"
+constructor_signatures['java/lang/Character'] = "(C)V"
+constructor_signatures['java/lang/Double'] = "(D)V"
+constructor_signatures['java/lang/Float'] = "(F)V"
+constructor_signatures['java/lang/Integer'] = "(I)V"
+constructor_signatures['java/lang/Long'] = "(J)V"
+constructor_signatures['java/lang/Short'] = "(S)V"
+constructor_signatures['java/util/List'] = None
+
+value_methods = {}
+value_methods['java/lang/Boolean'] = ("booleanValue", "()Z")
+value_methods['java/lang/Byte'] = ("byteValue", "()B")
+value_methods['java/lang/Character'] = ("charValue", "()C")
+value_methods['java/lang/Double'] = ("doubleValue", "()D")
+value_methods['java/lang/Float'] = ("floatValue", "()F")
+value_methods['java/lang/Integer'] = ("intValue", "()I")
+value_methods['java/lang/Long'] = ("longValue", "()J")
+value_methods['java/lang/Short'] = ("shortValue", "()S")
+
+jni_signatures = {}
+jni_signatures['java/lang/Boolean'] = "Z"
+jni_signatures['java/lang/Byte'] = "B"
+jni_signatures['java/lang/Character'] = "C"
+jni_signatures['java/lang/Double'] = "D"
+jni_signatures['java/lang/Float'] = "F"
+jni_signatures['java/lang/Integer'] = "I"
+jni_signatures['java/lang/Long'] = "J"
+jni_signatures['java/lang/Short'] = "S"
+
+non_primitive_types = set()
+
+def get_constructor_signature(type_, subfolder='msg'):
+    return constructor_signatures[get_jni_type(type_, subfolder=subfolder)]
+
+def get_value_method(type_, subfolder='msg'):
+    return value_methods.get(get_jni_type(type_, subfolder=subfolder))
+
+def get_jni_signature(type_, subfolder='msg'):
+    return jni_signatures.get(get_jni_type(type_, subfolder=subfolder))
+
+msg_normalized_type = get_normalized_type(spec.base_type, subfolder=subfolder)
+msg_jni_type = get_jni_type(spec.base_type, subfolder=subfolder)
+
+list_java_type = "java.util.List"
+array_list_java_type = "java.util.ArrayList"
+
+list_normalized_type = "java__util__List"
+list_jni_type = "java/util/List"
+
+array_list_normalized_type = "java__util__ArrayList"
+array_list_jni_type = "java/util/ArrayList"
+
+cache = defaultdict(lambda: False)
+
+cache[msg_normalized_type] = msg_jni_type
+
+# We do not cache strings because java.lang.String behaves differently
+
+for field in spec.fields:
+    if field.type.is_array:
+        cache[list_normalized_type] = list_jni_type
+        cache[array_list_normalized_type] = array_list_jni_type
+
+    if not field.type.type == 'string':
+        cache[get_normalized_type(field.type)] = get_jni_type(field.type)
+
+    if not field.type.is_primitive_type():
+        non_primitive_types.add(get_jni_type(field.type))
+}@
+
 @[for field in spec.fields]@
 @[    if not field.type.is_primitive_type()]@
 #include <@(field.type.pkg_name)/msg/@(convert_camel_case_to_lower_case_underscore(field.type.type)).h>
@@ -26,6 +114,37 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Initialize cached types in the anonymous namespace to avoid linking conflicts
+namespace {
+  JavaVM* g_vm = nullptr;
+
+@[for normalized_type, jni_type in cache.items()]@
+  jclass _j@(normalized_type)_class_global = nullptr;
+
+@[if constructor_signatures[jni_type]]@
+  jmethodID _j@(normalized_type)_constructor_global = nullptr;
+@[end if]@
+
+@[    if value_methods.get(jni_type)]@
+  jmethodID _j@(normalized_type)_value_global = nullptr;
+@[    end if]@
+
+@[    if jni_type in non_primitive_types]@
+  jmethodID _j@(normalized_type)_from_java_converter_global = nullptr;
+  using _j@(normalized_type)_from_java_signature = @(normalized_type) * (*)(jobject, @(normalized_type) *);
+  jlong _j@(normalized_type)_from_java_converter_ptr_global = 0;
+  _j@(normalized_type)_from_java_signature _j@(normalized_type)_from_java_function = nullptr;
+
+  jmethodID _j@(normalized_type)_to_java_converter_global = nullptr;
+  using _j@(normalized_type)_to_java_signature = jobject (*)(@(normalized_type) *, jobject);
+  jlong _j@(normalized_type)_to_java_converter_ptr_global = 0;
+  _j@(normalized_type)_to_java_signature _j@(normalized_type)_to_java_function = nullptr;
+@[    end if]@
+
+@[end for]@
+}
+
 /*
  * Class:     @(jni_package_name)_@(subfolder)_@(type_name)
  * Method:    getFromJavaConverter
@@ -54,15 +173,12 @@ JNIEXPORT jlong JNICALL Java_@(jni_package_name)_@(subfolder)_@(jni_type_name)_g
 }
 #endif
 
-@{
-msg_typename = '%s__%s__%s' % (spec.base_type.pkg_name, subfolder, spec.base_type.type)
-}@
-
-static_assert(sizeof(jlong) >= sizeof(intptr_t), "jlong must be able to store pointers");
-
-static JavaVM* g_vm = nullptr;
-
-@(msg_typename) * @(spec.base_type.pkg_name)_@(type_name)__convert_from_java(jobject _jmessage_obj, @(msg_typename) * ros_message)
+@# Avoid warnings about unused arguments if the message definition does not contain any fields
+@[if spec.fields]@
+@(msg_normalized_type) * @(spec.base_type.pkg_name)_@(type_name)__convert_from_java(jobject _jmessage_obj, @(msg_normalized_type) * ros_message)
+@[else]@
+@(msg_normalized_type) * @(spec.base_type.pkg_name)_@(type_name)__convert_from_java(jobject, @(msg_normalized_type) * ros_message)
+@[end if]@
 {
   JNIEnv *env = nullptr;
   // TODO(esteve): check return status
@@ -72,19 +188,20 @@ static JavaVM* g_vm = nullptr;
 
   if (ros_message == nullptr)
   {
-    ros_message = @(msg_typename)__create();
+    ros_message = @(msg_normalized_type)__create();
   }
-  auto _jmessage_class = env->GetObjectClass(_jmessage_obj);
 @[for field in spec.fields]@
+@{
+normalized_type = get_normalized_type(field.type)
+}@
 @[    if field.type.is_array]
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "Ljava/util/List;");
-  jclass _jlist_@(field.name)_class = env->FindClass("java/util/List");
+  auto _jfield_@(field.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(field.name)", "L@(list_jni_type);");
   jobject _jlist_@(field.name)_object = env->GetObjectField(_jmessage_obj, _jfield_@(field.name)_fid);
 
   if (_jlist_@(field.name)_object != nullptr) {
-    jmethodID _jlist_@(field.name)_get_mid = env->GetMethodID(_jlist_@(field.name)_class, "get", "(I)Ljava/lang/Object;");
+    jmethodID _jlist_@(field.name)_get_mid = env->GetMethodID(_j@(list_normalized_type)_class_global, "get", "(I)Ljava/lang/Object;");
 @[        if field.type.array_size is None or field.type.is_upper_bound]@
-    jmethodID _jlist_@(field.name)_size_mid = env->GetMethodID(_jlist_@(field.name)_class, "size", "()I");
+    jmethodID _jlist_@(field.name)_size_mid = env->GetMethodID(_j@(list_normalized_type)_class_global, "size", "()I");
     jint _jlist_@(field.name)_size = env->CallIntMethod(_jlist_@(field.name)_object, _jlist_@(field.name)_size_mid);
 @[            if field.type.type == 'string']@
     if (!rosidl_generator_c__String__Array__init(&(ros_message->@(field.name)), _jlist_@(field.name)_size)) {
@@ -110,142 +227,58 @@ static JavaVM* g_vm = nullptr;
 @[        end if]@
 
     for(jint i=0; i < _jlist_@(field.name)_size; ++i) {
-        auto element = env->CallObjectMethod(_jlist_@(field.name)_object, _jlist_@(field.name)_get_mid, i);
+      auto element = env->CallObjectMethod(_jlist_@(field.name)_object, _jlist_@(field.name)_get_mid, i);
 @[        if field.type.is_primitive_type()]@
-@[            if field.type.type == 'bool']@
-        jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Boolean");
-        jmethodID _jfield_@(field.name)_mid = env->GetMethodID(
-          _jfield_@(field.name)_class, "booleanValue", "()Z");
-        jboolean _jfield_@(field.name)_value = env->CallBooleanMethod(element, _jfield_@(field.name)_mid);
-        _dest_@(field.name)[i] = _jfield_@(field.name)_value;
-@[            elif field.type.type in ['byte', 'int8', 'uint8']]@
-        jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Byte");
-        jmethodID _jfield_@(field.name)_mid = env->GetMethodID(
-          _jfield_@(field.name)_class, "byteValue", "()B");
-        jbyte _jfield_@(field.name)_value = env->CallByteMethod(element, _jfield_@(field.name)_mid);
-        _dest_@(field.name)[i] = _jfield_@(field.name)_value;
-@[            elif field.type.type == 'char']@
-        jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Character");
-        jmethodID _jfield_@(field.name)_mid = env->GetMethodID(
-          _jfield_@(field.name)_class, "charValue", "()C");
-        jchar _jfield_@(field.name)_value = env->CallCharMethod(element, _jfield_@(field.name)_mid);
-        _dest_@(field.name)[i] = _jfield_@(field.name)_value;
-@[            elif field.type.type in ['int16', 'uint16']]@
-        jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Short");
-        jmethodID _jfield_@(field.name)_mid = env->GetMethodID(
-          _jfield_@(field.name)_class, "shortValue", "()S");
-        jshort _jfield_@(field.name)_value = env->CallShortMethod(element, _jfield_@(field.name)_mid);
-        _dest_@(field.name)[i] = _jfield_@(field.name)_value;
-@[            elif field.type.type in ['int32', 'uint32']]@
-        jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Integer");
-        jmethodID _jfield_@(field.name)_mid = env->GetMethodID(
-          _jfield_@(field.name)_class, "intValue", "()I");
-        jint _jfield_@(field.name)_value = env->CallIntMethod(element, _jfield_@(field.name)_mid);
-        _dest_@(field.name)[i] = _jfield_@(field.name)_value;
-@[            elif field.type.type in ['int64', 'uint64']]@
-        jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Long");
-        jmethodID _jfield_@(field.name)_mid = env->GetMethodID(
-          _jfield_@(field.name)_class, "longValue", "()J");
-        jlong _jfield_@(field.name)_value = env->CallLongMethod(element, _jfield_@(field.name)_mid);
-        _dest_@(field.name)[i] = _jfield_@(field.name)_value;
-@[            elif field.type.type == 'float32']@
-        jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Float");
-        jmethodID _jfield_@(field.name)_mid = env->GetMethodID(
-          _jfield_@(field.name)_class, "floatValue", "()F");
-        jfloat _jfield_@(field.name)_value = env->CallFloatMethod(element, _jfield_@(field.name)_mid);
-        _dest_@(field.name)[i] = _jfield_@(field.name)_value;
-@[            elif field.type.type == 'float64']@
-        jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Double");
-        jmethodID _jfield_@(field.name)_mid = env->GetMethodID(
-          _jfield_@(field.name)_class, "doubleValue", "()D");
-        jdouble _jfield_@(field.name)_value = env->CallDoubleMethod(element, _jfield_@(field.name)_mid);
-        _dest_@(field.name)[i] = _jfield_@(field.name)_value;
-@[            elif field.type.type == 'string']@
-        jstring _jfield_@(field.name)_value = static_cast<jstring>(element);
-        if (_jfield_@(field.name)_value != nullptr) {
-            const char * _str@(field.name) = env->GetStringUTFChars(_jfield_@(field.name)_value, 0);
-            rosidl_generator_c__String__assign(
-              &_dest_@(field.name)[i], _str@(field.name));
-            env->ReleaseStringUTFChars(_jfield_@(field.name)_value, _str@(field.name));
-        }
+@[            if field.type.type == 'string']@
+      jstring _jfield_@(field.name)_value = static_cast<jstring>(element);
+      if (_jfield_@(field.name)_value != nullptr) {
+        const char * _str@(field.name) = env->GetStringUTFChars(_jfield_@(field.name)_value, 0);
+        rosidl_generator_c__String__assign(
+          &_dest_@(field.name)[i], _str@(field.name));
+        env->ReleaseStringUTFChars(_jfield_@(field.name)_value, _str@(field.name));
+      }
+@[            else]@
+@{
+call_method_name = 'Call%sMethod' % get_java_type(field.type, use_primitives=True).capitalize()
+}@
+      _dest_@(field.name)[i] = env->@(call_method_name)(element, _j@(normalized_type)_value_global);
 @[            end if]@
 @[        else]@
-
-        jclass _jfield_@(field.name)_class = env->FindClass("@(field.type.pkg_name)/msg/@(get_java_type(field.type))");
-        assert(_jfield_@(field.name)_class != nullptr);
-
-        jmethodID _jfield_@(field.name)_from_java_converter_mid = env->GetStaticMethodID(
-          _jfield_@(field.name)_class, "getFromJavaConverter", "()J");
-        jlong _jfield_@(field.name)_from_java_converter_ptr = env->CallStaticLongMethod(
-          _jfield_@(field.name)_class, _jfield_@(field.name)_from_java_converter_mid);
-
-        using _convert_from_java_signature_@(field.name) = @(field.type.pkg_name)__msg__@(get_java_type(field.type)) * (*)(jobject, @(field.type.pkg_name)__msg__@(get_java_type(field.type)) *);
-
-        _convert_from_java_signature_@(field.name) convert_from_java_@(field.name) =
-          reinterpret_cast<_convert_from_java_signature_@(field.name)>(_jfield_@(field.name)_from_java_converter_ptr);
-
-        _dest_@(field.name)[i] = *convert_from_java_@(field.name)(element, nullptr);
+      _dest_@(field.name)[i] = *_j@(normalized_type)_from_java_function(element, nullptr);
 @[        end if]@
       env->DeleteLocalRef(element);
     }
   }
 @[    else]@
-@[        if field.type.type == 'string']@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "Ljava/lang/String;");
+@[        if field.type.is_primitive_type()]@
+@[            if field.type.type == 'string']@
+  auto _jfield_@(field.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(field.name)", "Ljava/lang/String;");
   jstring _jvalue@(field.name) = static_cast<jstring>(env->GetObjectField(_jmessage_obj, _jfield_@(field.name)_fid));
+
   if (_jvalue@(field.name) != nullptr) {
     const char * _str@(field.name) = env->GetStringUTFChars(_jvalue@(field.name), 0);
     rosidl_generator_c__String__assign(
       &ros_message->@(field.name), _str@(field.name));
     env->ReleaseStringUTFChars(_jvalue@(field.name), _str@(field.name));
   }
-@[        elif field.type.type == 'bool']@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "Z");
-  ros_message->@(field.name) = env->GetBooleanField(_jmessage_obj, _jfield_@(field.name)_fid);
-@[        elif field.type.type in ['byte', 'int8', 'uint8']]@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "B");
-  ros_message->@(field.name) = env->GetByteField(_jmessage_obj, _jfield_@(field.name)_fid);
-@[        elif field.type.type == 'char']@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "C");
-  ros_message->@(field.name) = env->GetCharField(_jmessage_obj, _jfield_@(field.name)_fid);
-@[        elif field.type.type in ['int16', 'uint16']]@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "S");
-  ros_message->@(field.name) = env->GetShortField(_jmessage_obj, _jfield_@(field.name)_fid);
-@[        elif field.type.type in ['int32', 'uint32']]@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "I");
-  ros_message->@(field.name) = env->GetIntField(_jmessage_obj, _jfield_@(field.name)_fid);
-@[        elif field.type.type in ['int64', 'uint64']]@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "J");
-  ros_message->@(field.name) = env->GetLongField(_jmessage_obj, _jfield_@(field.name)_fid);
-@[        elif field.type.type == 'float32']@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "F");
-  ros_message->@(field.name) = env->GetFloatField(_jmessage_obj, _jfield_@(field.name)_fid);
-@[        elif field.type.type == 'float64']@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "D");
-  ros_message->@(field.name) = env->GetDoubleField(_jmessage_obj, _jfield_@(field.name)_fid);
+@[            else]@
+@{
+jni_signature = get_jni_signature(field.type)
+get_method_name = 'Get%sField' % get_java_type(field.type, use_primitives=True).capitalize()
+}@
+  auto _jfield_@(field.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(field.name)", "@(jni_signature)");
+  ros_message->@(field.name) = env->@(get_method_name)(_jmessage_obj, _jfield_@(field.name)_fid);
+
+@[            end if]@
 @[        else]@
   auto _jfield_@(field.name)_fid = env->GetFieldID(
-    _jmessage_class, "@(field.name)", "L@(field.type.pkg_name)/msg/@(get_java_type(field.type));");
+    _j@(msg_normalized_type)_class_global, "@(field.name)", "L@(field.type.pkg_name)/msg/@(field.type.type);");
   assert(_jfield_@(field.name)_fid != nullptr);
 
   jobject _jfield_@(field.name)_obj = env->GetObjectField(_jmessage_obj, _jfield_@(field.name)_fid);
 
   if (_jfield_@(field.name)_obj != nullptr) {
-    auto _jfield_@(field.name)_class = env->FindClass(
-      "@(field.type.pkg_name)/msg/@(get_java_type(field.type))");
-    assert(_jfield_@(field.name)_class != nullptr);
-
-    jmethodID _jfield_@(field.name)_from_java_converter_mid = env->GetStaticMethodID(
-      _jfield_@(field.name)_class, "getFromJavaConverter", "()J");
-    jlong _jfield_@(field.name)_from_java_converter_ptr = env->CallStaticLongMethod(
-      _jfield_@(field.name)_class, _jfield_@(field.name)_from_java_converter_mid);
-
-    using _convert_from_java_signature_@(field.name) = @(field.type.pkg_name)__msg__@(get_java_type(field.type)) * (*)(jobject, @(field.type.pkg_name)__msg__@(get_java_type(field.type)) *);
-
-    _convert_from_java_signature_@(field.name) convert_from_java_@(field.name) =
-      reinterpret_cast<_convert_from_java_signature_@(field.name)>(_jfield_@(field.name)_from_java_converter_ptr);
-
-    ros_message->@(field.name) = *convert_from_java_@(field.name)(_jfield_@(field.name)_obj, nullptr);
+    ros_message->@(field.name) = *_j@(normalized_type)_from_java_function(_jfield_@(field.name)_obj, nullptr);
   }
   env->DeleteLocalRef(_jfield_@(field.name)_obj);
 @[        end if]@
@@ -255,7 +288,12 @@ static JavaVM* g_vm = nullptr;
   return ros_message;
 }
 
-jobject @(spec.base_type.pkg_name)_@(type_name)__convert_to_java(@(msg_typename) * _ros_message, jobject _jmessage_obj)
+@# Avoid warnings about unused arguments if the message definition does not contain any fields
+@[if spec.fields]@
+jobject @(spec.base_type.pkg_name)_@(type_name)__convert_to_java(@(msg_normalized_type) * _ros_message, jobject _jmessage_obj)
+@[else]@
+jobject @(spec.base_type.pkg_name)_@(type_name)__convert_to_java(@(msg_normalized_type) *, jobject _jmessage_obj)
+@[end if]@
 {
   JNIEnv *env = nullptr;
   // TODO(esteve): check return status
@@ -263,19 +301,18 @@ jobject @(spec.base_type.pkg_name)_@(type_name)__convert_to_java(@(msg_typename)
   g_vm->GetEnv((void**)&env, JNI_VERSION_1_6);
   assert(env != nullptr);
 
-  jclass _jmessage_class = env->FindClass("@(spec.base_type.pkg_name)/@(subfolder)/@(spec.base_type.type)");
   if (_jmessage_obj == nullptr)
   {
-    jmethodID _jmessage_constructor = env->GetMethodID(_jmessage_class, "<init>", "()V");
-    _jmessage_obj = env->NewObject(_jmessage_class, _jmessage_constructor);
+    _jmessage_obj = env->NewObject(_j@(msg_normalized_type)_class_global, _j@(msg_normalized_type)_constructor_global);
   }
 @[for field in spec.fields]@
+@{
+normalized_type = get_normalized_type(field.type)
+}@
 @[    if field.type.is_array]@
 @[        if field.type.is_primitive_type()]@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "Ljava/util/List;");
-  jclass _jarray_list_@(field.name)_class = env->FindClass("java/util/ArrayList");
-  jmethodID _jarray_list_@(field.name)_init_mid = env->GetMethodID(_jarray_list_@(field.name)_class, "<init>", "()V");
-  jobject _jarray_list_@(field.name)_obj = env->NewObject(_jarray_list_@(field.name)_class, _jarray_list_@(field.name)_init_mid);
+  auto _jfield_@(field.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(field.name)", "L@(list_jni_type);");
+  jobject _jarray_list_@(field.name)_obj = env->NewObject(_j@(array_list_normalized_type)_class_global, _j@(array_list_normalized_type)_constructor_global);
 @[            if field.type.array_size and not field.type.is_upper_bound]@
   for(size_t i = 0; i < @(field.type.array_size); ++i) {
     auto _ros_@(field.name)_element = _ros_message->@(field.name)[i];
@@ -289,42 +326,12 @@ jobject @(spec.base_type.pkg_name)_@(type_name)__convert_to_java(@(msg_typename)
       _jlist_@(field.name)_element = env->NewStringUTF(_ros_@(field.name)_element.data);
     }
 @[                else]@
-@[                    if field.type.type == 'bool']@
-    jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Boolean");
-    jmethodID _jlist_@(field.name)_init_mid = env->GetMethodID(_jfield_@(field.name)_class, "<init>", "(Z)V");
-    jobject _jlist_@(field.name)_element = env->NewObject(_jfield_@(field.name)_class, _jlist_@(field.name)_init_mid, _ros_@(field.name)_element);
-@[                    elif field.type.type in ['byte', 'int8', 'uint8']]@
-    jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Byte");
-    jmethodID _jlist_@(field.name)_init_mid = env->GetMethodID(_jfield_@(field.name)_class, "<init>", "(B)V");
-    jobject _jlist_@(field.name)_element = env->NewObject(_jfield_@(field.name)_class, _jlist_@(field.name)_init_mid, static_cast<jbyte>(_ros_@(field.name)_element));
-@[                    elif field.type.type == 'char']@
-    jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Character");
-    jmethodID _jlist_@(field.name)_init_mid = env->GetMethodID(_jfield_@(field.name)_class, "<init>", "(C)V");
-    jobject _jlist_@(field.name)_element = env->NewObject(_jfield_@(field.name)_class, _jlist_@(field.name)_init_mid, _ros_@(field.name)_element);
-@[                    elif field.type.type in ['int16', 'uint16']]@
-    jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Short");
-    jmethodID _jlist_@(field.name)_init_mid = env->GetMethodID(_jfield_@(field.name)_class, "<init>", "(S)V");
-    jobject _jlist_@(field.name)_element = env->NewObject(_jfield_@(field.name)_class, _jlist_@(field.name)_init_mid, _ros_@(field.name)_element);
-@[                    elif field.type.type in ['int32', 'uint32']]@
-    jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Integer");
-    jmethodID _jlist_@(field.name)_init_mid = env->GetMethodID(_jfield_@(field.name)_class, "<init>", "(I)V");
-    jobject _jlist_@(field.name)_element = env->NewObject(_jfield_@(field.name)_class, _jlist_@(field.name)_init_mid, _ros_@(field.name)_element);
-@[                    elif field.type.type in ['int64', 'uint64']]@
-    jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Long");
-    jmethodID _jlist_@(field.name)_init_mid = env->GetMethodID(_jfield_@(field.name)_class, "<init>", "(J)V");
-    jobject _jlist_@(field.name)_element = env->NewObject(_jfield_@(field.name)_class, _jlist_@(field.name)_init_mid, _ros_@(field.name)_element);
-@[                    elif field.type.type == 'float32']@
-    jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Float");
-    jmethodID _jlist_@(field.name)_init_mid = env->GetMethodID(_jfield_@(field.name)_class, "<init>", "(F)V");
-    jobject _jlist_@(field.name)_element = env->NewObject(_jfield_@(field.name)_class, _jlist_@(field.name)_init_mid, _ros_@(field.name)_element);
-@[                    elif field.type.type == 'float64']@
-    jclass _jfield_@(field.name)_class = env->FindClass("java/lang/Double");
-    jmethodID _jlist_@(field.name)_init_mid = env->GetMethodID(_jfield_@(field.name)_class, "<init>", "(D)V");
-    jobject _jlist_@(field.name)_element = env->NewObject(_jfield_@(field.name)_class, _jlist_@(field.name)_init_mid, _ros_@(field.name)_element);
-@[                    end if]@
+    jobject _jlist_@(field.name)_element = env->NewObject(
+      _j@(normalized_type)_class_global, _j@(normalized_type)_constructor_global, _ros_@(field.name)_element);
 @[                end if]@
     // TODO(esteve): replace ArrayList with a jobjectArray to initialize the array beforehand
-    jmethodID _jlist_@(field.name)_add_mid = env->GetMethodID(_jarray_list_@(field.name)_class, "add", "(Ljava/lang/Object;)Z");
+    jmethodID _jlist_@(field.name)_add_mid = env->GetMethodID(
+      _j@(array_list_normalized_type)_class_global, "add", "(Ljava/lang/Object;)Z");
     if (_jlist_@(field.name)_element != nullptr) {
       jboolean _jlist_@(field.name)_add_result = env->CallBooleanMethod(_jarray_list_@(field.name)_obj, _jlist_@(field.name)_add_mid, _jlist_@(field.name)_element);
       assert(_jlist_@(field.name)_add_result);
@@ -332,33 +339,18 @@ jobject @(spec.base_type.pkg_name)_@(type_name)__convert_to_java(@(msg_typename)
   }
 @[        else]@
 
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "Ljava/util/List;");
-  jclass _jarray_list_@(field.name)_class = env->FindClass("java/util/ArrayList");
-  jmethodID _jarray_list_@(field.name)_init_mid = env->GetMethodID(_jarray_list_@(field.name)_class, "<init>", "()V");
-  jobject _jarray_list_@(field.name)_obj = env->NewObject(_jarray_list_@(field.name)_class, _jarray_list_@(field.name)_init_mid);
-
-  jclass _jfield_@(field.name)_class = env->FindClass("@(field.type.pkg_name)/msg/@(get_java_type(field.type))");
-  assert(_jfield_@(field.name)_class != nullptr);
-
-  jmethodID _jfield_@(field.name)_to_java_converter_mid = env->GetStaticMethodID(
-    _jfield_@(field.name)_class, "getToJavaConverter", "()J");
-  jlong _jfield_@(field.name)_to_java_converter_ptr = env->CallStaticLongMethod(
-    _jfield_@(field.name)_class, _jfield_@(field.name)_to_java_converter_mid);
-
-  using _convert_to_java_signature_@(field.name) = jobject (*)(@(field.type.pkg_name)__msg__@(get_java_type(field.type)) *, jobject);
-
-  _convert_to_java_signature_@(field.name) convert_to_java_@(field.name) =
-    reinterpret_cast<_convert_to_java_signature_@(field.name)>(_jfield_@(field.name)_to_java_converter_ptr);
+  auto _jfield_@(field.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(field.name)", "L@(list_jni_type);");
+  jobject _jarray_list_@(field.name)_obj = env->NewObject(_j@(array_list_normalized_type)_class_global, _j@(array_list_normalized_type)_constructor_global);
 
 @[          if field.type.array_size and not field.type.is_upper_bound]@
   for(size_t i = 0; i < @(field.type.array_size); ++i) {
-  jobject _jlist_@(field.name)_element = convert_to_java_@(field.name)(&(_ros_message->@(field.name)[i]), nullptr);
+  jobject _jlist_@(field.name)_element = _j@(normalized_type)_to_java_function(&(_ros_message->@(field.name)[i]), nullptr);
 @[          else]@
   for(size_t i = 0; i < _ros_message->@(field.name).size; ++i) {
-  jobject _jlist_@(field.name)_element = convert_to_java_@(field.name)(&(_ros_message->@(field.name).data[i]), nullptr);
+  jobject _jlist_@(field.name)_element = _j@(normalized_type)_to_java_function(&(_ros_message->@(field.name).data[i]), nullptr);
 @[          end if]@
     // TODO(esteve): replace ArrayList with a jobjectArray to initialize the array beforehand
-    jmethodID _jlist_@(field.name)_add_mid = env->GetMethodID(_jarray_list_@(field.name)_class, "add", "(Ljava/lang/Object;)Z");
+    jmethodID _jlist_@(field.name)_add_mid = env->GetMethodID(_j@(array_list_normalized_type)_class_global, "add", "(Ljava/lang/Object;)Z");
     if (_jlist_@(field.name)_element != nullptr) {
       jboolean _jlist_@(field.name)_add_result = env->CallBooleanMethod(_jarray_list_@(field.name)_obj, _jlist_@(field.name)_add_mid, _jlist_@(field.name)_element);
       assert(_jlist_@(field.name)_add_result);
@@ -369,54 +361,26 @@ jobject @(spec.base_type.pkg_name)_@(type_name)__convert_to_java(@(msg_typename)
   env->SetObjectField(_jmessage_obj, _jfield_@(field.name)_fid, _jarray_list_@(field.name)_obj);
   env->DeleteLocalRef(_jarray_list_@(field.name)_obj);
 @[    else]@
-@[        if field.type.type == 'string']@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "Ljava/lang/String;");
+@[        if field.type.is_primitive_type()]@
+@[            if field.type.type == 'string']@
+  auto _jfield_@(field.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(field.name)", "Ljava/lang/String;");
   if (_ros_message->@(field.name).data != nullptr) {
       env->SetObjectField(_jmessage_obj, _jfield_@(field.name)_fid, env->NewStringUTF(_ros_message->@(field.name).data));
   }
-@[        elif field.type.type == 'bool']@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "Z");
-  env->SetBooleanField(_jmessage_obj, _jfield_@(field.name)_fid, _ros_message->@(field.name));
-@[        elif field.type.type in ['byte', 'int8', 'uint8']]@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "B");
-  env->SetByteField(_jmessage_obj, _jfield_@(field.name)_fid, _ros_message->@(field.name));
-@[        elif field.type.type == 'char']@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "C");
-  env->SetCharField(_jmessage_obj, _jfield_@(field.name)_fid, _ros_message->@(field.name));
-@[        elif field.type.type in ['int16', 'uint16']]@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "S");
-  env->SetShortField(_jmessage_obj, _jfield_@(field.name)_fid, _ros_message->@(field.name));
-@[        elif field.type.type in ['int32', 'uint32']]@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "I");
-  env->SetIntField(_jmessage_obj, _jfield_@(field.name)_fid, _ros_message->@(field.name));
-@[        elif field.type.type in ['int64', 'uint64']]@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "J");
-  env->SetLongField(_jmessage_obj, _jfield_@(field.name)_fid, _ros_message->@(field.name));
-@[        elif field.type.type == 'float32']@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "F");
-  env->SetFloatField(_jmessage_obj, _jfield_@(field.name)_fid, _ros_message->@(field.name));
-@[        elif field.type.type == 'float64']@
-  auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "D");
-  env->SetDoubleField(_jmessage_obj, _jfield_@(field.name)_fid, _ros_message->@(field.name));
+@[            else]@
+@{
+jni_signature = get_jni_signature(field.type)
+set_method_name = 'Set%sField' % get_java_type(field.type, use_primitives=True).capitalize()
+}@
+  auto _jfield_@(field.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(field.name)", "@(jni_signature)");
+  env->@(set_method_name)(_jmessage_obj, _jfield_@(field.name)_fid, _ros_message->@(field.name));
+@[            end if]@
 @[        else]@
   auto _jfield_@(field.name)_fid = env->GetFieldID(
-    _jmessage_class, "@(field.name)", "L@(field.type.pkg_name)/msg/@(get_java_type(field.type));");
+    _j@(msg_normalized_type)_class_global, "@(field.name)", "L@(field.type.pkg_name)/msg/@(field.type.type);");
   assert(_jfield_@(field.name)_fid != nullptr);
 
-  auto _jfield_@(field.name)_class = env->FindClass("@(field.type.pkg_name)/msg/@(get_java_type(field.type))");
-  assert(_jfield_@(field.name)_class != nullptr);
-
-  jmethodID _jfield_@(field.name)_to_java_converter_mid = env->GetStaticMethodID(
-    _jfield_@(field.name)_class, "getToJavaConverter", "()J");
-  jlong _jfield_@(field.name)_to_java_converter_ptr = env->CallStaticLongMethod(
-    _jfield_@(field.name)_class, _jfield_@(field.name)_to_java_converter_mid);
-
-  using _convert_to_java_signature_@(field.name) = jobject (*)(@(field.type.pkg_name)__msg__@(get_java_type(field.type)) *, jobject);
-
-  _convert_to_java_signature_@(field.name) convert_to_java_@(field.name) =
-    reinterpret_cast<_convert_to_java_signature_@(field.name)>(_jfield_@(field.name)_to_java_converter_ptr);
-
-  jobject _jfield_@(field.name)_obj = convert_to_java_@(field.name)(&(_ros_message->@(field.name)), nullptr);
+  jobject _jfield_@(field.name)_obj = _j@(normalized_type)_to_java_function(&(_ros_message->@(field.name)), nullptr);
 
   env->SetObjectField(_jmessage_obj, _jfield_@(field.name)_fid, _jfield_@(field.name)_obj);
 @[        end if]@
@@ -427,12 +391,110 @@ jobject @(spec.base_type.pkg_name)_@(type_name)__convert_to_java(@(msg_typename)
   return _jmessage_obj;
 }
 
-JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
+{
   // Can only call this once
   if(g_vm == nullptr) {
     g_vm = vm;
   }
+
+  JNIEnv* env;
+  if(g_vm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK)
+  {
+    return JNI_ERR;
+  } else {
+@[for normalized_type, jni_type in cache.items()]@
+    auto _j@(normalized_type)_class_local = env->FindClass("@(jni_type)");
+    assert(_j@(normalized_type)_class_local != nullptr);
+    _j@(normalized_type)_class_global = static_cast<jclass>(env->NewGlobalRef(_j@(normalized_type)_class_local));
+    env->DeleteLocalRef(_j@(normalized_type)_class_local);
+    assert(_j@(normalized_type)_class_global != nullptr);
+
+@[if constructor_signatures[jni_type]]@
+    _j@(normalized_type)_constructor_global = env->GetMethodID(_j@(normalized_type)_class_global, "<init>", "@(constructor_signatures[jni_type])");
+    assert(_j@(normalized_type)_constructor_global != nullptr);
+@[end if]@
+
+@{
+value_method = value_methods.get(jni_type)
+if value_method:
+    value_method_name, value_method_signature = value_method
+}@
+
+@[    if value_method]@
+    _j@(normalized_type)_value_global = env->GetMethodID(_j@(normalized_type)_class_global, "@(value_method_name)", "@(value_method_signature)");
+    assert(_j@(normalized_type)_value_global != nullptr);
+@[    end if]@
+
+@[    if jni_type in non_primitive_types]@
+    _j@(normalized_type)_from_java_converter_global = env->GetStaticMethodID(
+      _j@(normalized_type)_class_global, "getFromJavaConverter", "()J");
+    assert(_j@(normalized_type)_from_java_converter_global != nullptr);
+
+    _j@(normalized_type)_from_java_converter_ptr_global = env->CallStaticLongMethod(
+      _j@(normalized_type)_class_global, _j@(normalized_type)_from_java_converter_global);
+    assert(_j@(normalized_type)_from_java_converter_ptr_global != 0);
+
+    _j@(normalized_type)_from_java_function =
+      reinterpret_cast<_j@(normalized_type)_from_java_signature>(_j@(normalized_type)_from_java_converter_ptr_global);
+    assert(_j@(normalized_type)_from_java_function != nullptr);
+
+    _j@(normalized_type)_to_java_converter_global = env->GetStaticMethodID(
+      _j@(normalized_type)_class_global, "getToJavaConverter", "()J");
+    assert(_j@(normalized_type)_to_java_converter_global != nullptr);
+
+    _j@(normalized_type)_to_java_converter_ptr_global = env->CallStaticLongMethod(
+      _j@(normalized_type)_class_global, _j@(normalized_type)_to_java_converter_global);
+    assert(_j@(normalized_type)_to_java_converter_ptr_global != 0);
+
+    _j@(normalized_type)_to_java_function =
+      reinterpret_cast<_j@(normalized_type)_to_java_signature>(_j@(normalized_type)_to_java_converter_ptr_global);
+    assert(_j@(normalized_type)_to_java_function != nullptr);
+
+
+@[    end if]@
+
+
+@[end for]@
+  }
   return JNI_VERSION_1_6;
+}
+
+JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void*)
+{
+  assert(g_vm != nullptr);
+  assert(g_vm == vm);
+
+  JNIEnv* env;
+  if(g_vm->GetEnv((void**)&env, JNI_VERSION_1_6) == JNI_OK)
+  {
+@[for normalized_type, jni_type in cache.items()]@
+    if(_j@(normalized_type)_class_global != nullptr)
+    {
+      env->DeleteGlobalRef(_j@(normalized_type)_class_global);
+      _j@(normalized_type)_class_global = nullptr;
+
+@[    if constructor_signatures[jni_type]]@
+      _j@(normalized_type)_constructor_global = nullptr;
+@[    end if]@
+
+@[    if value_methods.get(jni_type)]@
+      _j@(normalized_type)_value_global = nullptr;
+@[    end if]@
+
+@[    if jni_type in non_primitive_types]@
+      _j@(normalized_type)_from_java_converter_global = nullptr;
+      _j@(normalized_type)_from_java_converter_ptr_global = 0;
+      _j@(normalized_type)_from_java_function = nullptr;
+
+      _j@(normalized_type)_to_java_converter_global = nullptr;
+      _j@(normalized_type)_to_java_converter_ptr_global = 0;
+      _j@(normalized_type)_to_java_function = nullptr;
+@[    end if]@
+
+    }
+@[end for]@
+  }
 }
 
 JNIEXPORT jlong JNICALL Java_@(jni_package_name)_@(subfolder)_@(jni_type_name)_getFromJavaConverter

--- a/rosidl_generator_java/resource/msg_support.entry_point.cpp.template
+++ b/rosidl_generator_java/resource/msg_support.entry_point.cpp.template
@@ -186,6 +186,7 @@ static JavaVM* g_vm = nullptr;
 
         _dest_@(field.name)[i] = *convert_from_java_@(field.name)(element, nullptr);
 @[        end if]@
+      env->DeleteLocalRef(element);
     }
   }
 @[    else]@
@@ -246,6 +247,7 @@ static JavaVM* g_vm = nullptr;
 
     ros_message->@(field.name) = *convert_from_java_@(field.name)(_jfield_@(field.name)_obj, nullptr);
   }
+  env->DeleteLocalRef(_jfield_@(field.name)_obj);
 @[        end if]@
 @[    end if]@
 @[end for]@
@@ -328,8 +330,6 @@ jobject @(spec.base_type.pkg_name)_@(type_name)__convert_to_java(@(msg_typename)
       assert(_jlist_@(field.name)_add_result);
     }
   }
-
-  env->SetObjectField(_jmessage_obj, _jfield_@(field.name)_fid, _jarray_list_@(field.name)_obj);
 @[        else]@
 
   auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "Ljava/util/List;");
@@ -365,9 +365,9 @@ jobject @(spec.base_type.pkg_name)_@(type_name)__convert_to_java(@(msg_typename)
     }
 
   }
-
-  env->SetObjectField(_jmessage_obj, _jfield_@(field.name)_fid, _jarray_list_@(field.name)_obj);
 @[        end if]@
+  env->SetObjectField(_jmessage_obj, _jfield_@(field.name)_fid, _jarray_list_@(field.name)_obj);
+  env->DeleteLocalRef(_jarray_list_@(field.name)_obj);
 @[    else]@
 @[        if field.type.type == 'string']@
   auto _jfield_@(field.name)_fid = env->GetFieldID(_jmessage_class, "@(field.name)", "Ljava/lang/String;");

--- a/rosidl_generator_java/resource/msg_support.entry_point.cpp.template
+++ b/rosidl_generator_java/resource/msg_support.entry_point.cpp.template
@@ -399,7 +399,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
   }
 
   JNIEnv* env;
-  if(g_vm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK)
+  if(g_vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK)
   {
     return JNI_ERR;
   } else {
@@ -466,7 +466,7 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void*)
   assert(g_vm == vm);
 
   JNIEnv* env;
-  if(g_vm->GetEnv((void**)&env, JNI_VERSION_1_6) == JNI_OK)
+  if(g_vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) == JNI_OK)
   {
 @[for normalized_type, jni_type in cache.items()]@
     if(_j@(normalized_type)_class_global != nullptr)

--- a/rosidl_generator_java/rosidl_generator_java/__init__.py
+++ b/rosidl_generator_java/rosidl_generator_java/__init__.py
@@ -183,31 +183,31 @@ def constant_value_to_java(type_, value):
 
 def get_builtin_java_type(type_, use_primitives=True):
     if type_ == 'bool':
-        return 'boolean' if use_primitives else 'Boolean'
+        return 'boolean' if use_primitives else 'java.lang.Boolean'
 
     if type_ == 'byte':
-        return 'byte' if use_primitives else 'Byte'
+        return 'byte' if use_primitives else 'java.lang.Byte'
 
     if type_ == 'char':
-        return 'char' if use_primitives else 'Character'
+        return 'char' if use_primitives else 'java.lang.Character'
 
     if type_ == 'float32':
-        return 'float' if use_primitives else 'Float'
+        return 'float' if use_primitives else 'java.lang.Float'
 
     if type_ == 'float64':
-        return 'double' if use_primitives else 'Double'
+        return 'double' if use_primitives else 'java.lang.Double'
 
     if type_ in ['int8', 'uint8']:
-        return 'byte' if use_primitives else 'Byte'
+        return 'byte' if use_primitives else 'java.lang.Byte'
 
     if type_ in ['int16', 'uint16']:
-        return 'short' if use_primitives else 'Short'
+        return 'short' if use_primitives else 'java.lang.Short'
 
     if type_ in ['int32', 'uint32']:
-        return 'int' if use_primitives else 'Integer'
+        return 'int' if use_primitives else 'java.lang.Integer'
 
     if type_ in ['int64', 'uint64']:
-        return 'long' if use_primitives else 'Long'
+        return 'long' if use_primitives else 'java.lang.Long'
 
     if type_ == 'string':
         return 'java.lang.String'
@@ -215,8 +215,8 @@ def get_builtin_java_type(type_, use_primitives=True):
     assert False, "unknown type '%s'" % type_
 
 
-def get_java_type(type_, use_primitives=True):
+def get_java_type(type_, use_primitives=True, subfolder='msg'):
     if not type_.is_primitive_type():
-        return type_.type
+        return '%s.%s.%s' % (type_.pkg_name, subfolder, type_.type)
 
     return get_builtin_java_type(type_.type, use_primitives=use_primitives)


### PR DESCRIPTION
This PR makes the JNI extensions to cache as many reflection lookups as it can, including:

- Looking up classes, methods and constructors
- Function pointers for converting between Java and ROS

This also deletes local references wherever it can. Not really needed because Java cleans up local references when returning from JNI, but there's a chance the local references table may fill up if it's too small (e.g. Android) and lots of objects are created (e.g. during list conversion).

CI:

Android: https://travis-ci.org/esteve/ros2_android/builds/179416917
Java: https://travis-ci.org/esteve/ros2_java/builds/179416920