### PR TITLE
Added interfaces to all classes

### DIFF
--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -34,7 +34,7 @@ macro(target)
     get_rcl_information("${rmw_implementation}" "rcl${target_suffix}")
   endif()
 
-  set(_jni_classes "RCLJava;Node;Publisher;Client")
+  set(_jni_classes "RCLJava;NodeImpl;PublisherImpl;ClientImpl")
 
   foreach(_jni_class ${_jni_classes})
 
@@ -84,10 +84,13 @@ endmacro()
 set(${PROJECT_NAME}_sources
   "src/main/java/org/ros2/rcljava/BiConsumer.java"
   "src/main/java/org/ros2/rcljava/Client.java"
+  "src/main/java/org/ros2/rcljava/ClientImpl.java"
   "src/main/java/org/ros2/rcljava/Consumer.java"
   "src/main/java/org/ros2/rcljava/Node.java"
+  "src/main/java/org/ros2/rcljava/NodeImpl.java"
   "src/main/java/org/ros2/rcljava/package-info.java"
   "src/main/java/org/ros2/rcljava/Publisher.java"
+  "src/main/java/org/ros2/rcljava/PublisherImpl.java"
   "src/main/java/org/ros2/rcljava/qos/policies/Durability.java"
   "src/main/java/org/ros2/rcljava/qos/policies/History.java"
   "src/main/java/org/ros2/rcljava/qos/policies/QoSPolicy.java"
@@ -97,7 +100,9 @@ set(${PROJECT_NAME}_sources
   "src/main/java/org/ros2/rcljava/RCLJava.java"
   "src/main/java/org/ros2/rcljava/RMWRequestId.java"
   "src/main/java/org/ros2/rcljava/Service.java"
+  "src/main/java/org/ros2/rcljava/ServiceImpl.java"
   "src/main/java/org/ros2/rcljava/Subscription.java"
+  "src/main/java/org/ros2/rcljava/SubscriptionImpl.java"
   "src/main/java/org/ros2/rcljava/TriConsumer.java"
 )
 

--- a/rcljava/include/org_ros2_rcljava_ClientImpl.h
+++ b/rcljava/include/org_ros2_rcljava_ClientImpl.h
@@ -13,23 +13,23 @@
 // limitations under the License.
 
 #include <jni.h>
-/* Header for class org_ros2_rcljava_Client */
+/* Header for class org_ros2_rcljava_ClientImpl */
 
-#ifndef ORG_ROS2_RCLJAVA_CLIENT_H_
-#define ORG_ROS2_RCLJAVA_CLIENT_H_
+#ifndef ORG_ROS2_RCLJAVA_CLIENTIMPL_H_
+#define ORG_ROS2_RCLJAVA_CLIENTIMPL_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 /*
- * Class:     org_ros2_rcljava_Client
+ * Class:     org_ros2_rcljava_ClientImpl
  * Method:    nativeSendClientRequest
  * Signature: (JJJJLjava/lang/Object;)V
  */
-JNIEXPORT void JNICALL Java_org_ros2_rcljava_Client_nativeSendClientRequest
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_ClientImpl_nativeSendClientRequest
   (JNIEnv *, jclass, jlong, jlong, jlong, jlong, jobject);
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // ORG_ROS2_RCLJAVA_CLIENT_H_
+#endif  // ORG_ROS2_RCLJAVA_CLIENTIMPL_H_

--- a/rcljava/include/org_ros2_rcljava_NodeImpl.h
+++ b/rcljava/include/org_ros2_rcljava_NodeImpl.h
@@ -13,48 +13,48 @@
 // limitations under the License.
 
 #include <jni.h>
-/* Header for class org_ros2_rcljava_Node */
+/* Header for class org_ros2_rcljava_NodeImpl */
 
-#ifndef ORG_ROS2_RCLJAVA_NODE_H_
-#define ORG_ROS2_RCLJAVA_NODE_H_
+#ifndef ORG_ROS2_RCLJAVA_NODEIMPL_H_
+#define ORG_ROS2_RCLJAVA_NODEIMPL_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 /*
- * Class:     org_ros2_rcljava_Node
+ * Class:     org_ros2_rcljava_NodeImpl
  * Method:    nativeCreatePublisherHandle
  * Signature: (JLjava/lang/Class;Ljava/lang/String;J)J
  */
-JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_Node_nativeCreatePublisherHandle
+JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_NodeImpl_nativeCreatePublisherHandle
   (JNIEnv *, jclass, jlong, jclass, jstring, jlong);
 
 /*
- * Class:     org_ros2_rcljava_Node
+ * Class:     org_ros2_rcljava_NodeImpl
  * Method:    nativeCreateSubscriptionHandle
  * Signature: (JLjava/lang/Class;Ljava/lang/String;J)J
  */
-JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_Node_nativeCreateSubscriptionHandle
+JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_NodeImpl_nativeCreateSubscriptionHandle
   (JNIEnv *, jclass, jlong, jclass, jstring, jlong);
 
 /*
- * Class:     org_ros2_rcljava_Node
+ * Class:     org_ros2_rcljava_NodeImpl
  * Method:    nativeCreateServiceHandle
  * Signature: (JLjava/lang/Class;Ljava/lang/String;J)J
  */
-JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_Node_nativeCreateServiceHandle
+JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_NodeImpl_nativeCreateServiceHandle
   (JNIEnv *, jclass, jlong, jclass, jstring, jlong);
 
 /*
- * Class:     org_ros2_rcljava_Node
+ * Class:     org_ros2_rcljava_NodeImpl
  * Method:    nativeCreateClientHandle
  * Signature: (JLjava/lang/Class;Ljava/lang/String;J)J
  */
-JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_Node_nativeCreateClientHandle
+JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_NodeImpl_nativeCreateClientHandle
   (JNIEnv *, jclass, jlong, jclass, jstring, jlong);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // ORG_ROS2_RCLJAVA_NODE_H_
+#endif  // ORG_ROS2_RCLJAVA_NODEIMPL_H_

--- a/rcljava/include/org_ros2_rcljava_PublisherImpl.h
+++ b/rcljava/include/org_ros2_rcljava_PublisherImpl.h
@@ -13,20 +13,20 @@
 // limitations under the License.
 
 #include <jni.h>
-/* Header for class org_ros2_rcljava_Publisher */
+/* Header for class org_ros2_rcljava_PublisherImpl */
 
-#ifndef ORG_ROS2_RCLJAVA_PUBLISHER_H_
-#define ORG_ROS2_RCLJAVA_PUBLISHER_H_
+#ifndef ORG_ROS2_RCLJAVA_PUBLISHERIMPL_H_
+#define ORG_ROS2_RCLJAVA_PUBLISHERIMPL_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 /*
- * Class:     org_ros2_rcljava_Publisher
+ * Class:     org_ros2_rcljava_PublisherImpl
  * Method:    nativePublish
  * Signature: (JLjava/lang/Object;)
  */
-JNIEXPORT void JNICALL Java_org_ros2_rcljava_Publisher_nativePublish
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_PublisherImpl_nativePublish
   (JNIEnv *, jclass, jlong, jobject);
 
 /*
@@ -34,11 +34,11 @@ JNIEXPORT void JNICALL Java_org_ros2_rcljava_Publisher_nativePublish
  * Method:    nativeDispose
  * Signature: (JJ)V
  */
-JNIEXPORT void JNICALL Java_org_ros2_rcljava_Publisher_nativeDispose
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_PublisherImpl_nativeDispose
   (JNIEnv *, jclass, jlong, jlong);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // ORG_ROS2_RCLJAVA_PUBLISHER_H_
+#endif  // ORG_ROS2_RCLJAVA_PUBLISHERIMPL_H_

--- a/rcljava/src/main/cpp/org_ros2_rcljava_ClientImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_ClientImpl.cpp
@@ -27,10 +27,10 @@
 #include "rcljava_common/exceptions.h"
 #include "rcljava_common/signatures.h"
 
-#include "org_ros2_rcljava_Client.h"
+#include "org_ros2_rcljava_ClientImpl.h"
 
-JNIEXPORT void JNICALL Java_org_ros2_rcljava_Client_nativeSendClientRequest(JNIEnv * env, jclass,
-  jlong client_handle, jlong sequence_number, jlong jrequest_from_java_converter_handle,
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_ClientImpl_nativeSendClientRequest(JNIEnv * env,
+  jclass, jlong client_handle, jlong sequence_number, jlong jrequest_from_java_converter_handle,
   jlong jrequest_to_java_converter_handle, jobject jrequest_msg)
 {
   assert(client_handle != 0);

--- a/rcljava/src/main/cpp/org_ros2_rcljava_NodeImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_NodeImpl.cpp
@@ -27,13 +27,10 @@
 #include "rcljava_common/exceptions.h"
 #include "rcljava_common/signatures.h"
 
-#include "org_ros2_rcljava_Node.h"
+#include "org_ros2_rcljava_NodeImpl.h"
 
-JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_Node_nativeCreatePublisherHandle(JNIEnv * env, jclass,
-  jlong node_handle,
-  jclass jmessage_class,
-  jstring jtopic,
-  jlong qos_profile_handle)
+JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_NodeImpl_nativeCreatePublisherHandle(JNIEnv * env,
+  jclass, jlong node_handle, jclass jmessage_class, jstring jtopic, jlong qos_profile_handle)
 {
   jmethodID mid = env->GetStaticMethodID(jmessage_class, "getTypeSupport", "()J");
   jlong jts = env->CallStaticLongMethod(jmessage_class, mid);
@@ -69,7 +66,7 @@ JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_Node_nativeCreatePublisherHandle(J
   return jpublisher;
 }
 
-JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_Node_nativeCreateSubscriptionHandle(JNIEnv * env,
+JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_NodeImpl_nativeCreateSubscriptionHandle(JNIEnv * env,
   jclass,
   jlong node_handle,
   jclass jmessage_class,
@@ -111,8 +108,8 @@ JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_Node_nativeCreateSubscriptionHandl
   return jsubscription;
 }
 
-JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_Node_nativeCreateServiceHandle(JNIEnv * env, jclass,
-  jlong node_handle, jclass jservice_class, jstring jservice_name, jlong qos_profile_handle)
+JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_NodeImpl_nativeCreateServiceHandle(JNIEnv * env,
+  jclass, jlong node_handle, jclass jservice_class, jstring jservice_name, jlong qos_profile_handle)
 {
   jmethodID mid = env->GetStaticMethodID(jservice_class, "getServiceTypeSupport", "()J");
 
@@ -153,8 +150,9 @@ JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_Node_nativeCreateServiceHandle(JNI
   return jservice;
 }
 
-JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_Node_nativeCreateClientHandle(JNIEnv * env, jclass,
-  jlong node_handle, jclass jservice_class, jstring jservice_name, jlong qos_profile_handle)
+JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_NodeImpl_nativeCreateClientHandle(JNIEnv * env,
+  jclass, jlong node_handle, jclass jservice_class, jstring jservice_name,
+  jlong qos_profile_handle)
 {
   jmethodID mid = env->GetStaticMethodID(jservice_class, "getServiceTypeSupport", "()J");
 

--- a/rcljava/src/main/cpp/org_ros2_rcljava_PublisherImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_PublisherImpl.cpp
@@ -27,9 +27,9 @@
 #include "rcljava_common/exceptions.h"
 #include "rcljava_common/signatures.h"
 
-#include "org_ros2_rcljava_Publisher.h"
+#include "org_ros2_rcljava_PublisherImpl.h"
 
-JNIEXPORT void JNICALL Java_org_ros2_rcljava_Publisher_nativePublish(JNIEnv * env, jclass,
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_PublisherImpl_nativePublish(JNIEnv * env, jclass,
   jlong publisher_handle,
   jobject jmsg)
 {
@@ -53,7 +53,7 @@ JNIEXPORT void JNICALL Java_org_ros2_rcljava_Publisher_nativePublish(JNIEnv * en
   }
 }
 
-JNIEXPORT void JNICALL Java_org_ros2_rcljava_Publisher_nativeDispose(JNIEnv * env, jclass,
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_PublisherImpl_nativeDispose(JNIEnv * env, jclass,
   jlong node_handle,
   jlong publisher_handle)
 {

--- a/rcljava/src/main/java/org/ros2/rcljava/ClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/ClientImpl.java
@@ -1,0 +1,109 @@
+/* Copyright 2016 Esteve Fernandez <esteve@apache.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ros2.rcljava;
+
+import org.ros2.rcljava.interfaces.MessageDefinition;
+import org.ros2.rcljava.interfaces.ServiceDefinition;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+public class ClientImpl<T extends ServiceDefinition> implements Client<T> {
+  private static final Logger logger = LoggerFactory.getLogger(ClientImpl.class);
+
+  static {
+    try {
+      System.loadLibrary("rcljavaClientImpl__" + RCLJava.getRMWIdentifier());
+    } catch (UnsatisfiedLinkError ule) {
+      logger.error("Native code library failed to load.\n" + ule);
+      System.exit(1);
+    }
+  }
+
+  private final WeakReference<Node> nodeReference;
+  private final long nodeHandle;
+  private final long clientHandle;
+  private final String serviceName;
+  private long sequenceNumber = 0;
+  private Map<Long, RCLFuture> pendingRequests;
+
+  private final Class<MessageDefinition> requestType;
+  private final Class<MessageDefinition> responseType;
+
+  public ClientImpl(final WeakReference<Node> nodeReference,
+      final long nodeHandle, final long clientHandle,
+      final String serviceName,
+      final Class<MessageDefinition> requestType,
+      final Class<MessageDefinition> responseType) {
+    this.nodeReference = nodeReference;
+    this.nodeHandle = nodeHandle;
+    this.clientHandle = clientHandle;
+    this.serviceName = serviceName;
+    this.requestType = requestType;
+    this.responseType = responseType;
+    this.pendingRequests = new HashMap<Long, RCLFuture>();
+  }
+
+  public final <U extends MessageDefinition, V extends MessageDefinition>
+      Future<V> sendRequest(final U request) {
+    synchronized (pendingRequests) {
+      sequenceNumber++;
+      nativeSendClientRequest(clientHandle, sequenceNumber,
+          request.getFromJavaConverterInstance(), request.getToJavaConverterInstance(),
+          request);
+      RCLFuture<V> future = new RCLFuture<V>(this.nodeReference);
+      pendingRequests.put(sequenceNumber, future);
+      return future;
+    }
+  }
+
+  public final <U extends MessageDefinition> void handleResponse(final RMWRequestId header,
+      final U response) {
+    synchronized (pendingRequests) {
+      long sequenceNumber = header.sequenceNumber;
+      RCLFuture<U> future = pendingRequests.remove(sequenceNumber);
+      future.set(response);
+    }
+  }
+
+  public final long getClientHandle() {
+    return clientHandle;
+  }
+
+  private static native void nativeSendClientRequest(long clientHandle,
+      long sequenceNumber, long requestFromJavaConverterHandle,
+      long requestToJavaConverterHandle, MessageDefinition requestMessage);
+
+  public final Class<MessageDefinition> getRequestType() {
+    return this.requestType;
+  }
+
+  public final Class<MessageDefinition> getResponseType() {
+    return this.responseType;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final void dispose() {
+    // TODO(esteve): implement
+  }
+}

--- a/rcljava/src/main/java/org/ros2/rcljava/NodeImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/NodeImpl.java
@@ -1,0 +1,278 @@
+/* Copyright 2016 Esteve Fernandez <esteve@apache.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ros2.rcljava;
+
+import org.ros2.rcljava.qos.QoSProfile;
+import org.ros2.rcljava.interfaces.MessageDefinition;
+import org.ros2.rcljava.interfaces.ServiceDefinition;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+
+import java.util.Collection;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * {@inheritDoc}
+ */
+public class NodeImpl implements Node {
+
+  private static final Logger logger = LoggerFactory.getLogger(NodeImpl.class);
+
+  static {
+    try {
+      System.loadLibrary("rcljavaNodeImpl__" + RCLJava.getRMWIdentifier());
+    } catch (UnsatisfiedLinkError ule) {
+      logger.error("Native code library failed to load.\n" + ule);
+      System.exit(1);
+    }
+  }
+
+  /**
+   * An integer that represents a pointer to the underlying ROS2 node
+   * structure (rcl_node_t).
+   */
+  private final long nodeHandle;
+
+  /**
+   * All the @{link Subscription}s that have been created through this instance.
+   */
+  private final Collection<Subscription> subscriptions;
+
+  /**
+   * All the @{link Publisher}s that have been created through this instance.
+   */
+  private final Collection<Publisher> publishers;
+
+  /**
+   * All the @{link Service}s that have been created through this instance.
+   */
+  private final Collection<Service> services;
+
+  /**
+   * All the @{link Client}s that have been created through this instance.
+   */
+  private final Collection<Client> clients;
+
+  /**
+   * Constructor.
+   *
+   * @param nodeHandle A pointer to the underlying ROS2 node structure. Must not
+   *     be zero.
+   */
+  public NodeImpl(final long nodeHandle) {
+    this.nodeHandle = nodeHandle;
+    this.publishers = new LinkedBlockingQueue<Publisher>();
+    this.subscriptions = new LinkedBlockingQueue<Subscription>();
+    this.services = new LinkedBlockingQueue<Service>();
+    this.clients = new LinkedBlockingQueue<Client>();
+  }
+
+  /**
+   * Create a ROS2 publisher (rcl_publisher_t) and return a pointer to
+   *     it as an integer.
+   *
+   * @param <T> The type of the messages that will be published by the
+   *     created @{link Publisher}.
+   * @param nodeHandle A pointer to the underlying ROS2 node structure.
+   * @param messageType The class of the messages that will be published by the
+   *     created @{link Publisher}.
+   * @param topic The topic to which the created @{link Publisher} will
+   *     publish messages.
+   * @param qosProfileHandle A pointer to the underlying ROS2 QoS profile
+   *     structure.
+   * @return A pointer to the underlying ROS2 publisher structure.
+   */
+  private static native <T extends MessageDefinition> long nativeCreatePublisherHandle(
+      long nodeHandle, Class<T> messageType, String topic,
+      long qosProfileHandle);
+
+  /**
+   * Create a ROS2 subscription (rcl_subscription_t) and return a pointer to
+   *     it as an integer.
+   *
+   * @param <T> The type of the messages that will be received by the
+   *     created @{link Subscription}.
+   * @param nodeHandle A pointer to the underlying ROS2 node structure.
+   * @param messageType The class of the messages that will be received by the
+   *     created @{link Subscription}.
+   * @param topic The topic from which the created @{link Subscription} will
+   *     receive messages.
+   * @param qosProfileHandle A pointer to the underlying ROS2 QoS profile
+   *     structure.
+   * @return A pointer to the underlying ROS2 subscription structure.
+   */
+  private static native <T extends MessageDefinition> long nativeCreateSubscriptionHandle(
+      long nodeHandle, Class<T> messageType, String topic,
+      long qosProfileHandle);
+
+  /**
+   * {@inheritDoc}
+   */
+  public final <T extends MessageDefinition> Publisher<T> createPublisher(
+      final Class<T> messageType, final String topic,
+      final QoSProfile qosProfile) {
+
+    long qosProfileHandle = RCLJava.convertQoSProfileToHandle(qosProfile);
+    long publisherHandle = nativeCreatePublisherHandle(this.nodeHandle,
+        messageType, topic, qosProfileHandle);
+    RCLJava.disposeQoSProfile(qosProfileHandle);
+
+    Publisher<T> publisher = new PublisherImpl<T>(this.nodeHandle,
+        publisherHandle, topic);
+    this.publishers.add(publisher);
+
+    return publisher;
+  }
+
+  public final <T extends MessageDefinition> Publisher<T> createPublisher(
+      final Class<T> messageType, final String topic) {
+    return this.<T>createPublisher(messageType, topic, QoSProfile.DEFAULT);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final <T extends MessageDefinition> Subscription<T> createSubscription(
+      final Class<T> messageType, final String topic,
+      final Consumer<T> callback, final QoSProfile qosProfile) {
+
+    long qosProfileHandle = RCLJava.convertQoSProfileToHandle(qosProfile);
+    long subscriptionHandle = nativeCreateSubscriptionHandle(
+        this.nodeHandle, messageType, topic, qosProfileHandle);
+    RCLJava.disposeQoSProfile(qosProfileHandle);
+
+    Subscription<T> subscription = new SubscriptionImpl<T>(
+        this.nodeHandle, subscriptionHandle, messageType, topic, callback);
+
+    this.subscriptions.add(subscription);
+
+    return subscription;
+  }
+
+  public final <T extends MessageDefinition> Subscription<T> createSubscription(
+      final Class<T> messageType, final String topic,
+      final Consumer<T> callback) {
+    return this.<T>createSubscription(messageType, topic, callback,
+      QoSProfile.DEFAULT);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final Collection<Subscription> getSubscriptions() {
+    return this.subscriptions;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final Collection<Publisher> getPublishers() {
+    return this.publishers;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final void dispose() {
+    // TODO(esteve): implement
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final long getNodeHandle() {
+    return this.nodeHandle;
+  }
+
+  private static native <T extends ServiceDefinition> long nativeCreateServiceHandle(
+      long nodeHandle, Class<T> cls, String serviceName,
+      long qosProfileHandle);
+
+  public final <T extends ServiceDefinition> Service<T> createService(final Class<T> serviceType,
+      final String serviceName, final TriConsumer<RMWRequestId, ? extends MessageDefinition, ? extends MessageDefinition> callback,
+      final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
+
+    Class<MessageDefinition> requestType = (Class) serviceType.getField("RequestType").get(null);
+
+    Class<MessageDefinition> responseType = (Class) serviceType.getField("ResponseType").get(null);
+
+    long qosProfileHandle = RCLJava.convertQoSProfileToHandle(qosProfile);
+    long serviceHandle = nativeCreateServiceHandle(this.nodeHandle, serviceType, serviceName,
+        qosProfileHandle);
+    RCLJava.disposeQoSProfile(qosProfileHandle);
+
+    Service<T> service = new ServiceImpl<T>(this.nodeHandle, serviceHandle,
+        serviceName,  callback, requestType, responseType);
+    this.services.add(service);
+
+    return service;
+  }
+
+  public <T extends ServiceDefinition> Service<T> createService(final Class<T> serviceType,
+      final String serviceName, final TriConsumer<RMWRequestId, ? extends MessageDefinition, ? extends MessageDefinition> callback)
+      throws NoSuchFieldException, IllegalAccessException {
+    return this.<T>createService(serviceType, serviceName, callback,
+      QoSProfile.SERVICES_DEFAULT);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final Collection<Service> getServices() {
+    return this.services;
+  }
+
+  public final <T extends ServiceDefinition> Client<T> createClient(final Class<T> serviceType,
+      final String serviceName, final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
+
+    Class<MessageDefinition> requestType = (Class) serviceType.getField("RequestType").get(null);
+
+    Class<MessageDefinition> responseType = (Class) serviceType.getField("ResponseType").get(null);
+
+    long qosProfileHandle = RCLJava.convertQoSProfileToHandle(qosProfile);
+    long clientHandle = nativeCreateClientHandle(this.nodeHandle, serviceType,
+        serviceName, qosProfileHandle);
+    RCLJava.disposeQoSProfile(qosProfileHandle);
+
+    Client<T> client = new ClientImpl<T>(new WeakReference<Node>(this),
+        this.nodeHandle, clientHandle, serviceName, requestType,
+        responseType);
+    this.clients.add(client);
+
+    return client;
+  }
+
+  public <T extends ServiceDefinition> Client<T> createClient(final Class<T> serviceType,
+      final String serviceName) throws NoSuchFieldException, IllegalAccessException {
+    return this.<T>createClient(serviceType, serviceName,
+      QoSProfile.SERVICES_DEFAULT);
+  }
+
+  private static native <T extends ServiceDefinition> long nativeCreateClientHandle(
+      long nodeHandle, Class<T> cls, String serviceName,
+      long qosProfileHandle);
+
+  /**
+   * {@inheritDoc}
+   */
+  public final Collection<Client> getClients() {
+    return this.clients;
+  }
+}

--- a/rcljava/src/main/java/org/ros2/rcljava/Publisher.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/Publisher.java
@@ -15,8 +15,8 @@
 
 package org.ros2.rcljava;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.ros2.rcljava.interfaces.Disposable;
+import org.ros2.rcljava.interfaces.MessageDefinition;
 
 /**
  * This class serves as a bridge between ROS2's rcl_publisher_t and RCLJava.
@@ -25,95 +25,23 @@ import org.slf4j.LoggerFactory;
  *
  * @param <T> The type of the messages that this publisher will publish.
  */
-public class Publisher<T> {
-
-  private static final Logger logger = LoggerFactory.getLogger(Publisher.class);
-
-  static {
-    try {
-      System.loadLibrary("rcljavaPublisher__" + RCLJava.getRMWIdentifier());
-    } catch (UnsatisfiedLinkError ule) {
-      logger.error("Native code library failed to load.\n" + ule);
-      System.exit(1);
-    }
-  }
-
-  /**
-   * An integer that represents a pointer to the underlying ROS2 node
-   * structure (rcl_node_t).
-   */
-  private final long nodeHandle;
-
-  /**
-   * An integer that represents a pointer to the underlying ROS2 publisher
-   * structure (rcl_publisher_t).
-   */
-  private final long publisherHandle;
-
-  /**
-   * The topic to which this publisher will publish messages.
-   */
-  private final String topic;
-
-  /**
-   * Constructor.
-   *
-   * @param nodeHandle A pointer to the underlying ROS2 node structure that
-   *     created this subscription, as an integer. Must not be zero.
-   * @param publisherHandle A pointer to the underlying ROS2 publisher
-   *     structure, as an integer. Must not be zero.
-   * @param topic The topic to which this publisher will publish messages.
-   */
-  public Publisher(final long nodeHandle, final long publisherHandle,
-      final String topic) {
-    this.nodeHandle = nodeHandle;
-    this.publisherHandle = publisherHandle;
-    this.topic = topic;
-  }
-
-  /**
-   * Publish a message via the underlying ROS2 mechanisms.
-   *
-   * @param <T> The type of the messages that this publisher will publish.
-   * @param publisherHandle A pointer to the underlying ROS2 publisher
-   *     structure, as an integer. Must not be zero.
-   * @param message An instance of the &lt;T&gt; parameter.
-   */
-  private static native <T> void nativePublish(
-      long publisherHandle, T message);
-
+public interface Publisher<T extends MessageDefinition> extends Disposable {
   /**
    * Publish a message.
    *
    * @param message An instance of the &lt;T&gt; parameter.
    */
-  public final void publish(final T message) {
-    nativePublish(this.publisherHandle, message);
-  }
+  void publish(final T message);
 
   /**
-   * Destroy a ROS2 publisher (rcl_publisher_t).
-   *
-   * @param nodeHandle A pointer to the underlying ROS2 node structure that
-   *     created this subscription, as an integer. Must not be zero.
-   * @param publisherHandle A pointer to the underlying ROS2 publisher
-   *     structure, as an integer. Must not be zero.
+   * An integer that represents a pointer to the underlying ROS2 node
+   * structure (rcl_node_t).
    */
-  private static native void nativeDispose(
-      long nodeHandle, long publisherHandle);
+  long getNodeHandle();
 
   /**
-   * Safely destroy the underlying ROS2 publisher structure.
+   * An integer that represents a pointer to the underlying ROS2 publisher
+   * structure (rcl_publisher_t).
    */
-  public final void dispose() {
-    nativeDispose(this.nodeHandle, this.publisherHandle);
-  }
-
-  public final long getNodeHandle() {
-    return this.nodeHandle;
-  }
-
-  public final long getPublisherHandle() {
-    return this.publisherHandle;
-  }
+  long getPublisherHandle();
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/PublisherImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/PublisherImpl.java
@@ -1,0 +1,121 @@
+/* Copyright 2016 Esteve Fernandez <esteve@apache.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ros2.rcljava;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.ros2.rcljava.interfaces.MessageDefinition;
+
+/**
+ * {@inheritDoc}
+ */
+public class PublisherImpl<T extends MessageDefinition> implements Publisher<T> {
+
+  private static final Logger logger = LoggerFactory.getLogger(PublisherImpl.class);
+
+  static {
+    try {
+      System.loadLibrary("rcljavaPublisherImpl__" + RCLJava.getRMWIdentifier());
+    } catch (UnsatisfiedLinkError ule) {
+      logger.error("Native code library failed to load.\n" + ule);
+      System.exit(1);
+    }
+  }
+
+  /**
+   * An integer that represents a pointer to the underlying ROS2 node
+   * structure (rcl_node_t).
+   */
+  private final long nodeHandle;
+
+  /**
+   * An integer that represents a pointer to the underlying ROS2 publisher
+   * structure (rcl_publisher_t).
+   */
+  private final long publisherHandle;
+
+  /**
+   * The topic to which this publisher will publish messages.
+   */
+  private final String topic;
+
+  /**
+   * Constructor.
+   *
+   * @param nodeHandle A pointer to the underlying ROS2 node structure that
+   *     created this subscription, as an integer. Must not be zero.
+   * @param publisherHandle A pointer to the underlying ROS2 publisher
+   *     structure, as an integer. Must not be zero.
+   * @param topic The topic to which this publisher will publish messages.
+   */
+  public PublisherImpl(final long nodeHandle, final long publisherHandle,
+      final String topic) {
+    this.nodeHandle = nodeHandle;
+    this.publisherHandle = publisherHandle;
+    this.topic = topic;
+  }
+
+  /**
+   * Publish a message via the underlying ROS2 mechanisms.
+   *
+   * @param <T> The type of the messages that this publisher will publish.
+   * @param publisherHandle A pointer to the underlying ROS2 publisher
+   *     structure, as an integer. Must not be zero.
+   * @param message An instance of the &lt;T&gt; parameter.
+   */
+  private static native <T extends MessageDefinition> void nativePublish(
+      long publisherHandle, T message);
+
+  /**
+   * {@inheritDoc}
+   */
+  public final void publish(final T message) {
+    nativePublish(this.publisherHandle, message);
+  }
+
+  /**
+   * Destroy a ROS2 publisher (rcl_publisher_t).
+   *
+   * @param nodeHandle A pointer to the underlying ROS2 node structure that
+   *     created this subscription, as an integer. Must not be zero.
+   * @param publisherHandle A pointer to the underlying ROS2 publisher
+   *     structure, as an integer. Must not be zero.
+   */
+  private static native void nativeDispose(
+      long nodeHandle, long publisherHandle);
+
+  /**
+   * {@inheritDoc}
+   */
+  public final void dispose() {
+    nativeDispose(this.nodeHandle, this.publisherHandle);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final long getNodeHandle() {
+    return this.nodeHandle;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final long getPublisherHandle() {
+    return this.publisherHandle;
+  }
+}

--- a/rcljava/src/main/java/org/ros2/rcljava/ServiceImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/ServiceImpl.java
@@ -1,0 +1,59 @@
+/* Copyright 2016 Esteve Fernandez <esteve@apache.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ros2.rcljava;
+
+import org.ros2.rcljava.interfaces.MessageDefinition;
+import org.ros2.rcljava.interfaces.ServiceDefinition;
+
+public class ServiceImpl<T extends ServiceDefinition> implements Service<T> {
+
+  private final long nodeHandle;
+  private final long serviceHandle;
+  private final String serviceName;
+  private final TriConsumer<RMWRequestId, ?, ?> callback;
+
+  private final Class<MessageDefinition> requestType;
+  private final Class<MessageDefinition> responseType;
+
+  public ServiceImpl(final long nodeHandle, final long serviceHandle,
+      final String serviceName,
+      final TriConsumer<RMWRequestId, ?, ?> callback,
+      final Class<MessageDefinition> requestType,
+      final Class<MessageDefinition> responseType) {
+    this.nodeHandle = nodeHandle;
+    this.serviceHandle = serviceHandle;
+    this.serviceName = serviceName;
+    this.callback = callback;
+    this.requestType = requestType;
+    this.responseType = responseType;
+  }
+
+  public final TriConsumer<RMWRequestId, ?, ?> getCallback() {
+    return callback;
+  }
+
+  public final long getServiceHandle() {
+    return serviceHandle;
+  }
+
+  public final Class<MessageDefinition> getRequestType() {
+    return this.requestType;
+  }
+
+  public final Class<MessageDefinition> getResponseType() {
+    return this.responseType;
+  }
+}

--- a/rcljava/src/main/java/org/ros2/rcljava/Subscription.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/Subscription.java
@@ -15,6 +15,8 @@
 
 package org.ros2.rcljava;
 
+import org.ros2.rcljava.interfaces.Disposable;
+
 /**
  * This class serves as a bridge between ROS2's rcl_subscription_t and RCLJava.
  * A Subscription must be created via
@@ -22,84 +24,25 @@ package org.ros2.rcljava;
  *
  * @param <T> The type of the messages that this subscription will receive.
  */
-public class Subscription<T> {
+public interface Subscription<T> extends Disposable {
+  /**
+   * @return The pointer to the underlying ROS2 subscription structure.
+   */
+  long getSubscriptionHandle();
 
   /**
-   * An integer that represents a pointer to the underlying ROS2 node
-   * structure (rcl_node_t).
+   * @return The type of the messages that this subscription may receive.
    */
-  private final long nodeHandle;
-
-  /**
-   * An integer that represents a pointer to the underlying ROS2 subscription
-   * structure (rcl_subsription_t).
-   */
-  private final long subscriptionHandle;
-
-  /**
-   * The class of the messages that this subscription may receive.
-   */
-  private final Class<T> messageType;
-
-  /**
-   * The topic to which this subscription is subscribed.
-   */
-  private final String topic;
-
-  /**
-   * The callback function that will be triggered when a new message is
-   * received.
-   */
-  private final Consumer<T> callback;
-
-  /**
-   * Constructor.
-   *
-   * @param nodeHandle A pointer to the underlying ROS2 node structure that
-   *     created this subscription, as an integer. Must not be zero.
-   * @param subscriptionHandle A pointer to the underlying ROS2 subscription
-   *     structure, as an integer. Must not be zero.
-   * @param messageType The <code>Class</code> of the messages that this
-   *     subscription will receive. We need this because of Java's type erasure,
-   *     which doesn't allow us to use the generic parameter of
-   *     @{link org.ros2.rcljava.Subscription} directly.
-   * @param topic The topic to which this subscription will be subscribed.
-   * @param callback The callback function that will be triggered when a new
-   *     message is received.
-   */
-  public Subscription(final long nodeHandle, final long subscriptionHandle,
-                      final Class<T> messageType, final String topic,
-                      final Consumer<T> callback) {
-    this.nodeHandle = nodeHandle;
-    this.subscriptionHandle = subscriptionHandle;
-    this.messageType = messageType;
-    this.topic = topic;
-    this.callback = callback;
-  }
+  Class<T> getMessageType();
 
   /**
    * @return The callback function that this subscription will trigger when
    *     a message is received.
    */
-  public final Consumer<T> getCallback() {
-    return callback;
-  }
+  Consumer<T> getCallback();
 
   /**
-   * @return The type of the messages that this subscription may receive.
+   * @return The pointer to the underlying ROS2 node structure.
    */
-  public final Class<T> getMessageType() {
-    return messageType;
-  }
-
-  /**
-   * @return The pointer to the underlying ROS2 subscription structure.
-   */
-  public final long getSubscriptionHandle() {
-    return subscriptionHandle;
-  }
-
-  public final long getNodeHandle() {
-    return this.nodeHandle;
-  }
+  long getNodeHandle();
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/SubscriptionImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/SubscriptionImpl.java
@@ -1,0 +1,114 @@
+/* Copyright 2016 Esteve Fernandez <esteve@apache.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ros2.rcljava;
+
+/**
+ * This class serves as a bridge between ROS2's rcl_subscription_t and RCLJava.
+ * A Subscription must be created via
+ * @{link Node#createSubscription(Class&lt;T&gt;, String, Consumer&lt;T&gt;)}
+ *
+ * @param <T> The type of the messages that this subscription will receive.
+ */
+public class SubscriptionImpl<T> implements Subscription<T> {
+
+  /**
+   * An integer that represents a pointer to the underlying ROS2 node
+   * structure (rcl_node_t).
+   */
+  private final long nodeHandle;
+
+  /**
+   * An integer that represents a pointer to the underlying ROS2 subscription
+   * structure (rcl_subsription_t).
+   */
+  private final long subscriptionHandle;
+
+  /**
+   * The class of the messages that this subscription may receive.
+   */
+  private final Class<T> messageType;
+
+  /**
+   * The topic to which this subscription is subscribed.
+   */
+  private final String topic;
+
+  /**
+   * The callback function that will be triggered when a new message is
+   * received.
+   */
+  private final Consumer<T> callback;
+
+  /**
+   * Constructor.
+   *
+   * @param nodeHandle A pointer to the underlying ROS2 node structure that
+   *     created this subscription, as an integer. Must not be zero.
+   * @param subscriptionHandle A pointer to the underlying ROS2 subscription
+   *     structure, as an integer. Must not be zero.
+   * @param messageType The <code>Class</code> of the messages that this
+   *     subscription will receive. We need this because of Java's type erasure,
+   *     which doesn't allow us to use the generic parameter of
+   *     @{link org.ros2.rcljava.Subscription} directly.
+   * @param topic The topic to which this subscription will be subscribed.
+   * @param callback The callback function that will be triggered when a new
+   *     message is received.
+   */
+  public SubscriptionImpl(final long nodeHandle, final long subscriptionHandle,
+                      final Class<T> messageType, final String topic,
+                      final Consumer<T> callback) {
+    this.nodeHandle = nodeHandle;
+    this.subscriptionHandle = subscriptionHandle;
+    this.messageType = messageType;
+    this.topic = topic;
+    this.callback = callback;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final Consumer<T> getCallback() {
+    return callback;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final Class<T> getMessageType() {
+    return messageType;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final long getSubscriptionHandle() {
+    return subscriptionHandle;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final long getNodeHandle() {
+    return this.nodeHandle;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final void dispose() {
+    // TODO(esteve): implement
+  }
+}

--- a/rcljava_common/CMakeLists.txt
+++ b/rcljava_common/CMakeLists.txt
@@ -27,6 +27,9 @@ set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.6" "-target" "1.6")
 
 set(${PROJECT_NAME}_java_sources
   "src/main/java/org/ros2/rcljava/common/RCLJavaProxy.java"
+  "src/main/java/org/ros2/rcljava/interfaces/Disposable.java"
+  "src/main/java/org/ros2/rcljava/interfaces/MessageDefinition.java"
+  "src/main/java/org/ros2/rcljava/interfaces/ServiceDefinition.java"
 )
 
 set(${PROJECT_NAME}_cpp_sources

--- a/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/Disposable.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/Disposable.java
@@ -13,17 +13,11 @@
  * limitations under the License.
  */
 
-package org.ros2.rcljava;
+package org.ros2.rcljava.interfaces;
 
-import org.ros2.rcljava.interfaces.MessageDefinition;
-import org.ros2.rcljava.interfaces.ServiceDefinition;
-
-public interface Service<T extends ServiceDefinition> {
-  long getServiceHandle();
-
-  <U extends MessageDefinition> Class<U> getRequestType();
-
-  <U extends MessageDefinition> Class<U> getResponseType();
-
-  TriConsumer<RMWRequestId, ?, ?> getCallback();
+public interface Disposable {
+  /**
+   * Safely destroy the underlying ROS2 structure.
+   */
+  void dispose();
 }

--- a/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/MessageDefinition.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/MessageDefinition.java
@@ -13,17 +13,13 @@
  * limitations under the License.
  */
 
-package org.ros2.rcljava;
+package org.ros2.rcljava.interfaces;
 
-import org.ros2.rcljava.interfaces.MessageDefinition;
-import org.ros2.rcljava.interfaces.ServiceDefinition;
+public interface MessageDefinition {
 
-public interface Service<T extends ServiceDefinition> {
-  long getServiceHandle();
+  public long getFromJavaConverterInstance();
 
-  <U extends MessageDefinition> Class<U> getRequestType();
+  public long getToJavaConverterInstance();
 
-  <U extends MessageDefinition> Class<U> getResponseType();
-
-  TriConsumer<RMWRequestId, ?, ?> getCallback();
+  public long getTypeSupportInstance();
 }

--- a/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/ServiceDefinition.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/ServiceDefinition.java
@@ -13,17 +13,7 @@
  * limitations under the License.
  */
 
-package org.ros2.rcljava;
+package org.ros2.rcljava.interfaces;
 
-import org.ros2.rcljava.interfaces.MessageDefinition;
-import org.ros2.rcljava.interfaces.ServiceDefinition;
-
-public interface Service<T extends ServiceDefinition> {
-  long getServiceHandle();
-
-  <U extends MessageDefinition> Class<U> getRequestType();
-
-  <U extends MessageDefinition> Class<U> getResponseType();
-
-  TriConsumer<RMWRequestId, ?, ?> getCallback();
+public interface ServiceDefinition {
 }

--- a/rosidl_generator_java/resource/msg.java.template
+++ b/rosidl_generator_java/resource/msg.java.template
@@ -1,6 +1,7 @@
 package @(package_name).@(subfolder);
 
 import org.ros2.rcljava.common.RCLJavaProxy;
+import org.ros2.rcljava.interfaces.MessageDefinition;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,7 +12,7 @@ import @(field.type.pkg_name).msg.@(field.type.type);
 @[    end if]@
 @[end for]@
 
-public final class @(type_name) {
+public final class @(type_name) implements MessageDefinition {
 
   private static final Logger logger = LoggerFactory.getLogger(@(type_name).class);
 
@@ -32,6 +33,18 @@ public final class @(type_name) {
   public static native long getFromJavaConverter();
   public static native long getToJavaConverter();
   public static native long getTypeSupport();
+
+  public long getFromJavaConverterInstance() {
+    return getFromJavaConverter();
+  }
+
+  public long getToJavaConverterInstance() {
+    return getToJavaConverter();
+  }
+
+  public long getTypeSupportInstance() {
+    return getTypeSupport();
+  }
 
 @[for constant in spec.constants]@
     public static final @(get_builtin_java_type(constant.type)) @(constant.name) = @(constant_value_to_java(constant.type, constant.value));

--- a/rosidl_generator_java/resource/srv.java.template
+++ b/rosidl_generator_java/resource/srv.java.template
@@ -1,11 +1,12 @@
 package @(package_name).@(subfolder);
 
 import org.ros2.rcljava.common.RCLJavaProxy;
+import org.ros2.rcljava.interfaces.ServiceDefinition;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class @(type_name) {
+public class @(type_name) implements ServiceDefinition {
 
   private static final Logger logger = LoggerFactory.getLogger(@(type_name).class);
 


### PR DESCRIPTION
This PR wraps all the ROS2 entities (messages, publishers, etc.) in interfaces. The most immediate advantage of this is that the logic in `RCLJava.spinOnce` got much simpler now.

CI:

Android: https://travis-ci.org/esteve/ros2_android/builds/179553857
Java: https://travis-ci.org/esteve/ros2_java/builds/179553845