### PR TITLE
Dispose entities

### DIFF
--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -34,7 +34,14 @@ macro(target)
     get_rcl_information("${rmw_implementation}" "rcl${target_suffix}")
   endif()
 
-  set(_jni_classes "RCLJava;NodeImpl;PublisherImpl;ClientImpl")
+  set(_jni_classes
+    "ClientImpl"
+    "NodeImpl"
+    "PublisherImpl"
+    "RCLJava"
+    "ServiceImpl"
+    "SubscriptionImpl"
+  )
 
   foreach(_jni_class ${_jni_classes})
 

--- a/rcljava/include/org_ros2_rcljava_NodeImpl.h
+++ b/rcljava/include/org_ros2_rcljava_NodeImpl.h
@@ -17,7 +17,6 @@
 
 #ifndef ORG_ROS2_RCLJAVA_NODEIMPL_H_
 #define ORG_ROS2_RCLJAVA_NODEIMPL_H_
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -53,8 +52,15 @@ JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_NodeImpl_nativeCreateServiceHandle
 JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_NodeImpl_nativeCreateClientHandle
   (JNIEnv *, jclass, jlong, jclass, jstring, jlong);
 
+/*
+ * Class:     org_ros2_rcljava_NodeImpl
+ * Method:    nativeDispose
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_NodeImpl_nativeDispose
+  (JNIEnv *, jclass, jlong);
+
 #ifdef __cplusplus
 }
 #endif
-
 #endif  // ORG_ROS2_RCLJAVA_NODEIMPL_H_

--- a/rcljava/include/org_ros2_rcljava_PublisherImpl.h
+++ b/rcljava/include/org_ros2_rcljava_PublisherImpl.h
@@ -17,20 +17,19 @@
 
 #ifndef ORG_ROS2_RCLJAVA_PUBLISHERIMPL_H_
 #define ORG_ROS2_RCLJAVA_PUBLISHERIMPL_H_
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 /*
  * Class:     org_ros2_rcljava_PublisherImpl
  * Method:    nativePublish
- * Signature: (JLjava/lang/Object;)
+ * Signature: (JLorg/ros2/rcljava/interfaces/MessageDefinition;)V
  */
 JNIEXPORT void JNICALL Java_org_ros2_rcljava_PublisherImpl_nativePublish
   (JNIEnv *, jclass, jlong, jobject);
 
 /*
- * Class:     org_ros2_rcljava_Node
+ * Class:     org_ros2_rcljava_PublisherImpl
  * Method:    nativeDispose
  * Signature: (JJ)V
  */
@@ -40,5 +39,4 @@ JNIEXPORT void JNICALL Java_org_ros2_rcljava_PublisherImpl_nativeDispose
 #ifdef __cplusplus
 }
 #endif
-
 #endif  // ORG_ROS2_RCLJAVA_PUBLISHERIMPL_H_

--- a/rcljava/include/org_ros2_rcljava_RCLJava.h
+++ b/rcljava/include/org_ros2_rcljava_RCLJava.h
@@ -17,7 +17,6 @@
 
 #ifndef ORG_ROS2_RCLJAVA_RCLJAVA_H_
 #define ORG_ROS2_RCLJAVA_RCLJAVA_H_
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -104,7 +103,7 @@ JNIEXPORT void JNICALL Java_org_ros2_rcljava_RCLJava_nativeWait
 /*
  * Class:     org_ros2_rcljava_RCLJava
  * Method:    nativeTake
- * Signature: (JLjava/lang/Class;)Ljava/lang/Object;
+ * Signature: (JLjava/lang/Class;)Lorg/ros2/rcljava/interfaces/MessageDefinition;
  */
 JNIEXPORT jobject JNICALL Java_org_ros2_rcljava_RCLJava_nativeTake
   (JNIEnv *, jclass, jlong, jclass);
@@ -144,7 +143,7 @@ JNIEXPORT void JNICALL Java_org_ros2_rcljava_RCLJava_nativeWaitSetAddClient
 /*
  * Class:     org_ros2_rcljava_RCLJava
  * Method:    nativeTakeRequest
- * Signature: (JJJLjava/lang/Object;)Ljava/lang/Object;
+ * Signature: (JJJLorg/ros2/rcljava/interfaces/MessageDefinition;)Lorg/ros2/rcljava/RMWRequestId;
  */
 JNIEXPORT jobject JNICALL Java_org_ros2_rcljava_RCLJava_nativeTakeRequest
   (JNIEnv *, jclass, jlong, jlong, jlong, jobject);
@@ -152,7 +151,7 @@ JNIEXPORT jobject JNICALL Java_org_ros2_rcljava_RCLJava_nativeTakeRequest
 /*
  * Class:     org_ros2_rcljava_RCLJava
  * Method:    nativeSendServiceResponse
- * Signature: (JLjava/lang/Object;JJLjava/lang/Object;)V
+ * Signature: (JLorg/ros2/rcljava/RMWRequestId;JJLorg/ros2/rcljava/interfaces/MessageDefinition;)V
  */
 JNIEXPORT void JNICALL Java_org_ros2_rcljava_RCLJava_nativeSendServiceResponse
   (JNIEnv *, jclass, jlong, jobject, jlong, jlong, jobject);
@@ -160,7 +159,7 @@ JNIEXPORT void JNICALL Java_org_ros2_rcljava_RCLJava_nativeSendServiceResponse
 /*
  * Class:     org_ros2_rcljava_RCLJava
  * Method:    nativeTakeResponse
- * Signature: (JJJLjava/lang/Object;)Ljava/lang/Object;
+ * Signature: (JJJLorg/ros2/rcljava/interfaces/MessageDefinition;)Lorg/ros2/rcljava/RMWRequestId;
  */
 JNIEXPORT jobject JNICALL Java_org_ros2_rcljava_RCLJava_nativeTakeResponse
   (JNIEnv *, jclass, jlong, jlong, jlong, jobject);
@@ -184,5 +183,4 @@ JNIEXPORT void JNICALL Java_org_ros2_rcljava_RCLJava_nativeDisposeQoSProfile
 #ifdef __cplusplus
 }
 #endif
-
 #endif  // ORG_ROS2_RCLJAVA_RCLJAVA_H_

--- a/rcljava/include/org_ros2_rcljava_ServiceImpl.h
+++ b/rcljava/include/org_ros2_rcljava_ServiceImpl.h
@@ -13,30 +13,22 @@
 // limitations under the License.
 
 #include <jni.h>
-/* Header for class org_ros2_rcljava_ClientImpl */
+/* Header for class org_ros2_rcljava_ServiceImpl */
 
-#ifndef ORG_ROS2_RCLJAVA_CLIENTIMPL_H_
-#define ORG_ROS2_RCLJAVA_CLIENTIMPL_H_
+#ifndef ORG_ROS2_RCLJAVA_SERVICEIMPL_H_
+#define ORG_ROS2_RCLJAVA_SERVICEIMPL_H_
 #ifdef __cplusplus
 extern "C" {
 #endif
 /*
- * Class:     org_ros2_rcljava_ClientImpl
- * Method:    nativeSendClientRequest
- * Signature: (JJJJLorg/ros2/rcljava/interfaces/MessageDefinition;)V
- */
-JNIEXPORT void JNICALL Java_org_ros2_rcljava_ClientImpl_nativeSendClientRequest
-  (JNIEnv *, jclass, jlong, jlong, jlong, jlong, jobject);
-
-/*
- * Class:     org_ros2_rcljava_ClientImpl
+ * Class:     org_ros2_rcljava_ServiceImpl
  * Method:    nativeDispose
  * Signature: (JJ)V
  */
-JNIEXPORT void JNICALL Java_org_ros2_rcljava_ClientImpl_nativeDispose
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_ServiceImpl_nativeDispose
   (JNIEnv *, jclass, jlong, jlong);
 
 #ifdef __cplusplus
 }
 #endif
-#endif  // ORG_ROS2_RCLJAVA_CLIENTIMPL_H_
+#endif  // ORG_ROS2_RCLJAVA_SERVICEIMPL_H_

--- a/rcljava/include/org_ros2_rcljava_SubscriptionImpl.h
+++ b/rcljava/include/org_ros2_rcljava_SubscriptionImpl.h
@@ -13,30 +13,22 @@
 // limitations under the License.
 
 #include <jni.h>
-/* Header for class org_ros2_rcljava_ClientImpl */
+/* Header for class org_ros2_rcljava_SubscriptionImpl */
 
-#ifndef ORG_ROS2_RCLJAVA_CLIENTIMPL_H_
-#define ORG_ROS2_RCLJAVA_CLIENTIMPL_H_
+#ifndef ORG_ROS2_RCLJAVA_SUBSCRIPTIONIMPL_H_
+#define ORG_ROS2_RCLJAVA_SUBSCRIPTIONIMPL_H_
 #ifdef __cplusplus
 extern "C" {
 #endif
 /*
- * Class:     org_ros2_rcljava_ClientImpl
- * Method:    nativeSendClientRequest
- * Signature: (JJJJLorg/ros2/rcljava/interfaces/MessageDefinition;)V
- */
-JNIEXPORT void JNICALL Java_org_ros2_rcljava_ClientImpl_nativeSendClientRequest
-  (JNIEnv *, jclass, jlong, jlong, jlong, jlong, jobject);
-
-/*
- * Class:     org_ros2_rcljava_ClientImpl
+ * Class:     org_ros2_rcljava_SubscriptionImpl
  * Method:    nativeDispose
  * Signature: (JJ)V
  */
-JNIEXPORT void JNICALL Java_org_ros2_rcljava_ClientImpl_nativeDispose
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_SubscriptionImpl_nativeDispose
   (JNIEnv *, jclass, jlong, jlong);
 
 #ifdef __cplusplus
 }
 #endif
-#endif  // ORG_ROS2_RCLJAVA_CLIENTIMPL_H_
+#endif  // ORG_ROS2_RCLJAVA_SUBSCRIPTIONIMPL_H_

--- a/rcljava/src/main/cpp/org_ros2_rcljava_ClientImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_ClientImpl.cpp
@@ -53,3 +53,33 @@ JNIEXPORT void JNICALL Java_org_ros2_rcljava_ClientImpl_nativeSendClientRequest(
       "Failed to send request from a client: " + std::string(rcl_get_error_string_safe()));
   }
 }
+
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_ClientImpl_nativeDispose(JNIEnv * env, jclass,
+  jlong node_handle, jlong client_handle)
+{
+  if (client_handle == 0) {
+    // everything is ok, already destroyed
+    return;
+  }
+
+  if (node_handle == 0) {
+    // TODO(esteve): handle this, node is null, but client isn't
+    return;
+  }
+
+  rcl_node_t * node = reinterpret_cast<rcl_node_t *>(node_handle);
+
+  assert(node != NULL);
+
+  rcl_client_t * client = reinterpret_cast<rcl_client_t *>(client_handle);
+
+  assert(client != NULL);
+
+  rcl_ret_t ret = rcl_client_fini(client, node);
+
+  if (ret != RCL_RET_OK) {
+    rcljava_throw_exception(
+      env, "java/lang/IllegalStateException",
+      "Failed to destroy client: " + std::string(rcl_get_error_string_safe()));
+  }
+}

--- a/rcljava/src/main/cpp/org_ros2_rcljava_NodeImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_NodeImpl.cpp
@@ -192,3 +192,22 @@ JNIEXPORT jlong JNICALL Java_org_ros2_rcljava_NodeImpl_nativeCreateClientHandle(
   jlong jclient = reinterpret_cast<jlong>(client);
   return jclient;
 }
+
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_NodeImpl_nativeDispose(JNIEnv * env, jclass,
+  jlong node_handle)
+{
+  if (node_handle == 0) {
+    // already destroyed
+    return;
+  }
+
+  rcl_node_t * node = reinterpret_cast<rcl_node_t *>(node_handle);
+
+  rcl_ret_t ret = rcl_node_fini(node);
+
+  if (ret != RCL_RET_OK) {
+    rcljava_throw_exception(
+      env, "java/lang/IllegalStateException",
+      "Failed to destroy node: " + std::string(rcl_get_error_string_safe()));
+  }
+}

--- a/rcljava/src/main/cpp/org_ros2_rcljava_PublisherImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_PublisherImpl.cpp
@@ -57,9 +57,17 @@ JNIEXPORT void JNICALL Java_org_ros2_rcljava_PublisherImpl_nativeDispose(JNIEnv 
   jlong node_handle,
   jlong publisher_handle)
 {
-  rcl_node_t * node = reinterpret_cast<rcl_node_t *>(node_handle);
+  if (publisher_handle == 0) {
+    // everything is ok, already destroyed
+    return;
+  }
 
-  assert(node != NULL);
+  if (node_handle == 0) {
+    // TODO(esteve): handle this, node is null, but publisher isn't
+    return;
+  }
+
+  rcl_node_t * node = reinterpret_cast<rcl_node_t *>(node_handle);
 
   rcl_publisher_t * publisher = reinterpret_cast<rcl_publisher_t *>(publisher_handle);
 

--- a/rcljava/src/main/cpp/org_ros2_rcljava_ServiceImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_ServiceImpl.cpp
@@ -1,0 +1,60 @@
+// Copyright 2016 Esteve Fernandez <esteve@apache.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <jni.h>
+
+#include <cassert>
+#include <cstdlib>
+#include <string>
+
+#include "rmw/rmw.h"
+#include "rcl/error_handling.h"
+#include "rcl/rcl.h"
+#include "rcl/node.h"
+#include "rosidl_generator_c/message_type_support.h"
+
+#include "rcljava_common/exceptions.h"
+#include "rcljava_common/signatures.h"
+
+#include "org_ros2_rcljava_ServiceImpl.h"
+
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_ServiceImpl_nativeDispose(JNIEnv * env, jclass,
+  jlong node_handle, jlong service_handle)
+{
+  if (service_handle == 0) {
+    // everything is ok, already destroyed
+    return;
+  }
+
+  if (node_handle == 0) {
+    // TODO(esteve): handle this, node is null, but service isn't
+    return;
+  }
+
+  rcl_node_t * node = reinterpret_cast<rcl_node_t *>(node_handle);
+
+  assert(node != NULL);
+
+  rcl_service_t * service = reinterpret_cast<rcl_service_t *>(service_handle);
+
+  assert(service != NULL);
+
+  rcl_ret_t ret = rcl_service_fini(service, node);
+
+  if (ret != RCL_RET_OK) {
+    rcljava_throw_exception(
+      env, "java/lang/IllegalStateException",
+      "Failed to destroy service: " + std::string(rcl_get_error_string_safe()));
+  }
+}

--- a/rcljava/src/main/cpp/org_ros2_rcljava_SubscriptionImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_SubscriptionImpl.cpp
@@ -1,0 +1,60 @@
+// Copyright 2016 Esteve Fernandez <esteve@apache.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <jni.h>
+
+#include <cassert>
+#include <cstdlib>
+#include <string>
+
+#include "rmw/rmw.h"
+#include "rcl/error_handling.h"
+#include "rcl/rcl.h"
+#include "rcl/node.h"
+#include "rosidl_generator_c/message_type_support.h"
+
+#include "rcljava_common/exceptions.h"
+#include "rcljava_common/signatures.h"
+
+#include "org_ros2_rcljava_SubscriptionImpl.h"
+
+JNIEXPORT void JNICALL Java_org_ros2_rcljava_SubscriptionImpl_nativeDispose(JNIEnv * env, jclass,
+  jlong node_handle, jlong subscription_handle)
+{
+  if (subscription_handle == 0) {
+    // everything is ok, already destroyed
+    return;
+  }
+
+  if (node_handle == 0) {
+    // TODO(esteve): handle this, node is null, but subscription isn't
+    return;
+  }
+
+  rcl_node_t * node = reinterpret_cast<rcl_node_t *>(node_handle);
+
+  assert(node != NULL);
+
+  rcl_subscription_t * subscription = reinterpret_cast<rcl_subscription_t *>(subscription_handle);
+
+  assert(subscription != NULL);
+
+  rcl_ret_t ret = rcl_subscription_fini(subscription, node);
+
+  if (ret != RCL_RET_OK) {
+    rcljava_throw_exception(
+      env, "java/lang/IllegalStateException",
+      "Failed to destroy subscription: " + std::string(rcl_get_error_string_safe()));
+  }
+}

--- a/rcljava/src/main/java/org/ros2/rcljava/Client.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/Client.java
@@ -22,8 +22,6 @@ import org.ros2.rcljava.interfaces.MessageDefinition;
 import org.ros2.rcljava.interfaces.ServiceDefinition;
 
 public interface Client<T extends ServiceDefinition> extends Disposable {
-  long getClientHandle();
-
   <U extends MessageDefinition> Class<U> getRequestType();
 
   <U extends MessageDefinition> Class<U> getResponseType();

--- a/rcljava/src/main/java/org/ros2/rcljava/Node.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/Node.java
@@ -48,12 +48,6 @@ public interface Node extends Disposable {
   Collection<Publisher> getPublishers();
 
   /**
-   * An integer that represents a pointer to the underlying ROS2 node
-   * structure (rcl_node_t).
-   */
-  long getNodeHandle();
-
-  /**
    * Create a Subscription&lt;T&gt;.
    *
    * @param <T> The type of the messages that will be received by the

--- a/rcljava/src/main/java/org/ros2/rcljava/Publisher.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/Publisher.java
@@ -15,6 +15,8 @@
 
 package org.ros2.rcljava;
 
+import java.lang.ref.WeakReference;
+
 import org.ros2.rcljava.interfaces.Disposable;
 import org.ros2.rcljava.interfaces.MessageDefinition;
 
@@ -34,14 +36,8 @@ public interface Publisher<T extends MessageDefinition> extends Disposable {
   void publish(final T message);
 
   /**
-   * An integer that represents a pointer to the underlying ROS2 node
-   * structure (rcl_node_t).
+   * A @{link java.lang.ref.WeakReference} to the @{link org.ros2.rcljava.Node}
+   * that created this publisher.
    */
-  long getNodeHandle();
-
-  /**
-   * An integer that represents a pointer to the underlying ROS2 publisher
-   * structure (rcl_publisher_t).
-   */
-  long getPublisherHandle();
+  WeakReference<Node> getNodeReference();
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
@@ -45,6 +45,29 @@ public final class RCLJava {
    */
   private static Collection<Node> nodes;
 
+  private static void cleanup() {
+    for (Node node : nodes) {
+      for (Subscription subscription : node.getSubscriptions()) {
+        subscription.dispose();
+      }
+
+      for (Publisher publisher : node.getPublishers()) {
+        publisher.dispose();
+      }
+
+      for (Service service : node.getServices()) {
+        service.dispose();
+      }
+
+      for (Client client : node.getClients()) {
+        client.dispose();
+      }
+
+      node.dispose();
+    }
+  }
+
+
   static {
     nodes = new LinkedBlockingQueue<Node>();
 
@@ -58,9 +81,7 @@ public final class RCLJava {
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
       public void run() {
-        for (Node node : nodes) {
-          node.dispose();
-        }
+        cleanup();
       }
     });
   }
@@ -305,6 +326,7 @@ public final class RCLJava {
   private static native void nativeShutdown();
 
   public static void shutdown() {
+    cleanup();
     nativeShutdown();
   }
 

--- a/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
@@ -204,22 +204,22 @@ public final class RCLJava {
 
     for (Subscription<MessageDefinition> subscription : node.getSubscriptions()) {
       nativeWaitSetAddSubscription(
-          waitSetHandle, subscription.getSubscriptionHandle());
+          waitSetHandle, subscription.getHandle());
     }
 
     for (Service<ServiceDefinition> service : node.getServices()) {
-      nativeWaitSetAddService(waitSetHandle, service.getServiceHandle());
+      nativeWaitSetAddService(waitSetHandle, service.getHandle());
     }
 
     for (Client<ServiceDefinition> client : node.getClients()) {
-      nativeWaitSetAddClient(waitSetHandle, client.getClientHandle());
+      nativeWaitSetAddClient(waitSetHandle, client.getHandle());
     }
 
     nativeWait(waitSetHandle);
 
     for (Subscription<MessageDefinition> subscription : node.getSubscriptions()) {
       MessageDefinition message = nativeTake(
-          subscription.getSubscriptionHandle(),
+          subscription.getHandle(),
           subscription.getMessageType());
       if (message != null) {
         subscription.getCallback().accept(message);
@@ -254,12 +254,12 @@ public final class RCLJava {
           responseMessage.getToJavaConverterInstance();
 
       RMWRequestId rmwRequestId =
-          nativeTakeRequest(service.getServiceHandle(),
+          nativeTakeRequest(service.getHandle(),
           requestFromJavaConverterHandle, requestToJavaConverterHandle,
           requestMessage);
       if (rmwRequestId != null) {
         service.getCallback().accept(rmwRequestId, requestMessage, responseMessage);
-        nativeSendServiceResponse(service.getServiceHandle(), rmwRequestId,
+        nativeSendServiceResponse(service.getHandle(), rmwRequestId,
             responseFromJavaConverterHandle, responseToJavaConverterHandle,
             responseMessage);
       }
@@ -293,7 +293,7 @@ public final class RCLJava {
           responseMessage.getToJavaConverterInstance();
 
       RMWRequestId rmwRequestId = nativeTakeResponse(
-          client.getClientHandle(), responseFromJavaConverterHandle,
+          client.getHandle(), responseFromJavaConverterHandle,
           responseToJavaConverterHandle, responseMessage);
 
       if (rmwRequestId != null) {

--- a/rcljava/src/main/java/org/ros2/rcljava/Service.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/Service.java
@@ -15,12 +15,11 @@
 
 package org.ros2.rcljava;
 
+import org.ros2.rcljava.interfaces.Disposable;
 import org.ros2.rcljava.interfaces.MessageDefinition;
 import org.ros2.rcljava.interfaces.ServiceDefinition;
 
-public interface Service<T extends ServiceDefinition> {
-  long getServiceHandle();
-
+public interface Service<T extends ServiceDefinition> extends Disposable {
   <U extends MessageDefinition> Class<U> getRequestType();
 
   <U extends MessageDefinition> Class<U> getResponseType();

--- a/rcljava/src/main/java/org/ros2/rcljava/Subscription.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/Subscription.java
@@ -15,6 +15,8 @@
 
 package org.ros2.rcljava;
 
+import java.lang.ref.WeakReference;
+
 import org.ros2.rcljava.interfaces.Disposable;
 
 /**
@@ -25,11 +27,6 @@ import org.ros2.rcljava.interfaces.Disposable;
  * @param <T> The type of the messages that this subscription will receive.
  */
 public interface Subscription<T> extends Disposable {
-  /**
-   * @return The pointer to the underlying ROS2 subscription structure.
-   */
-  long getSubscriptionHandle();
-
   /**
    * @return The type of the messages that this subscription may receive.
    */
@@ -42,7 +39,8 @@ public interface Subscription<T> extends Disposable {
   Consumer<T> getCallback();
 
   /**
-   * @return The pointer to the underlying ROS2 node structure.
+   * @return A @{link java.lang.ref.WeakReference} to the
+   * @{link org.ros2.rcljava.Node}that created this subscription.
    */
-  long getNodeHandle();
+  WeakReference<Node> getNodeReference();
 }

--- a/rcljava/src/test/java/org/ros2/rcljava/ClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/ClientTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -76,6 +77,10 @@ public class ClientTest {
     node.dispose();
   }
 
+  @AfterClass
+  public static void tearDownOnce() {
+    RCLJava.shutdown();
+  }
 
   @Test
   public final void testAdd() throws Exception {
@@ -83,7 +88,7 @@ public class ClientTest {
       new RCLFuture<rcljava.srv.AddTwoInts_Response>(new WeakReference<Node>(node));
 
     TestClientConsumer clientConsumer = new TestClientConsumer(future);
- 
+
     Service<rcljava.srv.AddTwoInts> service = node.<
         rcljava.srv.AddTwoInts
         >createService(
@@ -105,5 +110,9 @@ public class ClientTest {
     }
 
     assertEquals(5, future.get().getSum());
+    client.dispose();
+    assertEquals(0, client.getHandle());
+    service.dispose();
+    assertEquals(0, service.getHandle());
   }
 }

--- a/rcljava/src/test/java/org/ros2/rcljava/NodeTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/NodeTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -166,9 +168,19 @@ public class NodeTest {
     primitives2.setStringValue(stringValue2);
   }
 
+  @After
+  public void tearDown() {
+    node.dispose();
+  }
+
+  @AfterClass
+  public static void tearDownOnce() {
+    RCLJava.shutdown();
+  }
+
   @Test
   public final void testCreate() {
-    assertNotEquals(0, node.getNodeHandle());
+    assertNotEquals(0, node.getHandle());
   }
 
   @Test
@@ -193,6 +205,11 @@ public class NodeTest {
 
     std_msgs.msg.String value = future.get();
     assertEquals("Hello", value.getData());
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -235,6 +252,11 @@ public class NodeTest {
         float32Value2, float64Value2, int8Value2, uint8Value2, int16Value2,
         uint16Value2, int32Value2, uint32Value2, int64Value2, uint64Value2,
         stringValue2));
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -305,6 +327,11 @@ public class NodeTest {
     assertEquals(int64Values, value.getInt64Values());
     assertEquals(uint64Values, value.getUint64Values());
     assertEquals(stringValues, value.getStringValues());
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -349,6 +376,11 @@ public class NodeTest {
 
     assertEquals(4321, timeValue.getSec());
     assertEquals(7654, timeValue.getNanosec());
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -391,6 +423,11 @@ public class NodeTest {
         float32Value2, float64Value2, int8Value2, uint8Value2, int16Value2,
         uint16Value2, int32Value2, uint32Value2, int64Value2, uint64Value2,
         stringValue2));
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -461,6 +498,11 @@ public class NodeTest {
     assertEquals(int64Values, value.getInt64Values());
     assertEquals(uint64Values, value.getUint64Values());
     assertEquals(stringValues, value.getStringValues());
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -487,6 +529,11 @@ public class NodeTest {
 
     rcljava.msg.Empty value = future.get();
     assertNotEquals(null, value);
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -532,6 +579,11 @@ public class NodeTest {
         float32Value2, float64Value2, int8Value2, uint8Value2, int16Value2,
         uint16Value2, int32Value2, uint32Value2, int64Value2, uint64Value2,
         stringValue2));
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -567,6 +619,11 @@ public class NodeTest {
         float32Value1, float64Value1, int8Value1, uint8Value1, int16Value1,
         uint16Value1, int32Value1, uint32Value1, int64Value1, uint64Value1,
         stringValue1));
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -597,6 +654,11 @@ public class NodeTest {
         float32Value1, float64Value1, int8Value1, uint8Value1, int16Value1,
         uint16Value1, int32Value1, uint32Value1, int64Value1, uint64Value1,
         stringValue1));
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -655,6 +717,11 @@ public class NodeTest {
         float32Value2, float64Value2, int8Value2, uint8Value2, int16Value2,
         uint16Value2, int32Value2, uint32Value2, int64Value2, uint64Value2,
         stringValue2));
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -725,6 +792,11 @@ public class NodeTest {
     assertEquals(int64Values, value.getInt64Values());
     assertEquals(uint64Values, value.getUint64Values());
     assertEquals(stringValues, value.getStringValues());
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 
   @Test
@@ -749,5 +821,10 @@ public class NodeTest {
 
     rcljava.msg.UInt32 value = future.get();
     assertEquals(12345, value.getData());
+
+    publisher.dispose();
+    assertEquals(0, publisher.getHandle());
+    subscription.dispose();
+    assertEquals(0, subscription.getHandle());
   }
 }

--- a/rcljava/src/test/java/org/ros2/rcljava/PublisherTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/PublisherTest.java
@@ -29,8 +29,8 @@ public class PublisherTest {
     Publisher<std_msgs.msg.String> publisher = node
         .<std_msgs.msg.String>createPublisher(std_msgs.msg.String.class,
         "test_topic");
-    assertEquals(node.getNodeHandle(), publisher.getNodeHandle());
-    assertNotEquals(0, publisher.getNodeHandle());
-    assertNotEquals(0, publisher.getPublisherHandle());
+    assertEquals(node.getHandle(), publisher.getNodeReference().get().getHandle());
+    assertNotEquals(0, publisher.getNodeReference().get().getHandle());
+    assertNotEquals(0, publisher.getHandle());
   }
 }

--- a/rcljava/src/test/java/org/ros2/rcljava/SubscriptionTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/SubscriptionTest.java
@@ -33,8 +33,8 @@ public class SubscriptionTest {
           }
         }
     );
-    assertEquals(node.getNodeHandle(), subscription.getNodeHandle());
-    assertNotEquals(0, subscription.getNodeHandle());
-    assertNotEquals(0, subscription.getSubscriptionHandle());
+    assertEquals(node.getHandle(), subscription.getNodeReference().get().getHandle());
+    assertNotEquals(0, subscription.getNodeReference().get().getHandle());
+    assertNotEquals(0, subscription.getHandle());
   }
 }

--- a/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/Disposable.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/Disposable.java
@@ -20,4 +20,10 @@ public interface Disposable {
    * Safely destroy the underlying ROS2 structure.
    */
   void dispose();
+
+  /**
+   * An integer that represents a pointer to the underlying ROS2
+   * structure.
+   */
+  long getHandle();
 }


### PR DESCRIPTION
Added `dispose()` to all JNI bridge classes so they can be properly cleaned up.
Added `getHandle()` to the `Disposable` interface to homogenize JNI handle access.

CI:

Android: https://travis-ci.org/esteve/ros2_android/builds/180038123
Java: https://travis-ci.org/esteve/ros2_java/builds/180038083