### PR TITLE
Added environment hooks for setting the CLASSPATH environment variable

### DIFF
--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -5,11 +5,17 @@ project(rcljava)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_export_jars REQUIRED)
 find_package(rcl REQUIRED)
+find_package(rcljava_common REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
-find_package(rcljava_common REQUIRED)
 
 include(CrossCompilingExtra)
+
+if(WIN32)
+  ament_environment_hooks(template/environment_hook/classpath.bat.in)
+else()
+  ament_environment_hooks(template/environment_hook/classpath.sh.in)
+endif()
 
 if(ANDROID)
   find_host_package(Java COMPONENTS Development)

--- a/rcljava/template/environment_hook/classpath.bat.in
+++ b/rcljava/template/environment_hook/classpath.bat.in
@@ -1,0 +1,2 @@
+ament_prepend_unique_value CLASSPATH "."
+ament_prepend_unique_value CLASSPATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/java/*"

--- a/rcljava/template/environment_hook/classpath.sh.in
+++ b/rcljava/template/environment_hook/classpath.sh.in
@@ -1,0 +1,2 @@
+ament_prepend_unique_value CLASSPATH "."
+ament_prepend_unique_value CLASSPATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/java/*"

--- a/rcljava_common/CMakeLists.txt
+++ b/rcljava_common/CMakeLists.txt
@@ -3,13 +3,18 @@ cmake_minimum_required(VERSION 3.5)
 project(rcljava_common)
 
 find_package(ament_cmake REQUIRED)
-
 find_package(ament_cmake_export_jars REQUIRED)
 find_package(ament_cmake_export_libraries REQUIRED)
 
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
 include(CrossCompilingExtra)
+
+if(WIN32)
+  ament_environment_hooks(template/environment_hook/classpath.bat.in)
+else()
+  ament_environment_hooks(template/environment_hook/classpath.sh.in)
+endif()
 
 if(ANDROID)
   find_host_package(Java COMPONENTS Development REQUIRED)

--- a/rcljava_common/template/environment_hook/classpath.bat.in
+++ b/rcljava_common/template/environment_hook/classpath.bat.in
@@ -1,0 +1,2 @@
+ament_prepend_unique_value CLASSPATH "."
+ament_prepend_unique_value CLASSPATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/java/*"

--- a/rcljava_common/template/environment_hook/classpath.sh.in
+++ b/rcljava_common/template/environment_hook/classpath.sh.in
@@ -1,0 +1,2 @@
+ament_prepend_unique_value CLASSPATH "."
+ament_prepend_unique_value CLASSPATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/java/*"


### PR DESCRIPTION
Export `CLASSPATH` environment variable so that JARs can be imported from the command line without further tweaks.