### PR TITLE
Fix up rmw repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ vcs import src < ros2_java_desktop.repos
 ament build --symlink-install --isolated
 ```
 
-To use OpenSplice or Connext DDS implementations, uncomment those repositories from `ros2_java_desktop.repos`
-
 > On Windows, if you would like to use OpenSplice, call `call "C:\opensplice67\HDE\x86_64.win64\release.bat"` before building.
 
 Now you can just run a bunch of examples, head over to https://github.com/esteve/ros2_java_examples for more information.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ vcs import src < ros2_java_desktop.repos
 ament build --symlink-install --isolated
 ```
 
+To use OpenSplice or Connext DDS implementations, uncomment those repositories from `ros2_java_desktop.repos`
+
 > On Windows, if you would like to use OpenSplice, call `call "C:\opensplice67\HDE\x86_64.win64\release.bat"` before building.
 
 Now you can just run a bunch of examples, head over to https://github.com/esteve/ros2_java_examples for more information.

--- a/ros2_java_desktop.repos
+++ b/ros2_java_desktop.repos
@@ -79,14 +79,14 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw.git
     version: master
-  # ros2/rmw_connext:
-  #   type: git
-  #   url: https://github.com/ros2/rmw_connext.git
-  #   version: master
-  # ros2/rosidl_typesupport_connext:
-  #   type: git
-  #   url: https://github.com/ros2/rosidl_typesupport_connext.git
-  #   version: master
+  ros2/rmw_connext:
+    type: git
+    url: https://github.com/ros2/rmw_connext.git
+    version: master
+  ros2/rosidl_typesupport_connext:
+    type: git
+    url: https://github.com/ros2/rosidl_typesupport_connext.git
+    version: master
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
@@ -95,14 +95,14 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
     version: master
-  # ros2/rmw_opensplice:
-  #   type: git
-  #   url: https://github.com/ros2/rmw_opensplice.git
-  #   version: master
-  # ros2/rosidl_typesupport_opensplice:
-  #   type: git
-  #   url: https://github.com/ros2/rosidl_typesupport_opensplice.git
-  #   version: master
+  ros2/rmw_opensplice:
+    type: git
+    url: https://github.com/ros2/rmw_opensplice.git
+    version: master
+  ros2/rosidl_typesupport_opensplice:
+    type: git
+    url: https://github.com/ros2/rosidl_typesupport_opensplice.git
+    version: master
   ros2/ros1_bridge:
     type: git
     url: https://github.com/ros2/ros1_bridge.git

--- a/ros2_java_desktop.repos
+++ b/ros2_java_desktop.repos
@@ -79,10 +79,14 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw.git
     version: master
-  ros2/rmw_connext:
-    type: git
-    url: https://github.com/ros2/rmw_connext.git
-    version: master
+  # ros2/rmw_connext:
+  #   type: git
+  #   url: https://github.com/ros2/rmw_connext.git
+  #   version: master
+  # ros2/rosidl_typesupport_connext:
+  #   type: git
+  #   url: https://github.com/ros2/rosidl_typesupport_connext.git
+  #   version: master
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
@@ -91,10 +95,14 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
     version: master
-#  ros2/rmw_opensplice:
-#    type: git
-#    url: https://github.com/ros2/rmw_opensplice.git
-#    version: master
+  # ros2/rmw_opensplice:
+  #   type: git
+  #   url: https://github.com/ros2/rmw_opensplice.git
+  #   version: master
+  # ros2/rosidl_typesupport_opensplice:
+  #   type: git
+  #   url: https://github.com/ros2/rosidl_typesupport_opensplice.git
+  #   version: master
   ros2/ros1_bridge:
     type: git
     url: https://github.com/ros2/ros1_bridge.git


### PR DESCRIPTION
@esteve Should I uncomment them by default instead? Connext was uncommented before, but I think that's the least common implementation because it is not free.

It seems the build will pass either way.